### PR TITLE
Refactoritza la configuració de valors_defecte

### DIFF
--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -19,24 +19,17 @@ class FiltreNou(Filtre):
     return self.solicitant!=None
 
   def obtenir_parametres_addicionals(self):
-    recipient=self.msg.get_to()
-    mail_from=self.msg.get_from()
-    mail_resent_from=self.msg.get_resent_from()
-
+    header_order=[ 'From', 'Resent-From', 'To' ]
     valors_defecte=settings.get("valors_defecte")
     equip_resolutor_nous=settings.get("equip_resolutor_nous")
     parametres_addicionals={"equipResolutor":equip_resolutor_nous}
 
-    if mail_from in valors_defecte:
-      logger.info("Tinc parametres adicionals per qui envia %s" % mail_from)
-      parametres_addicionals=valors_defecte[mail_from]
-    if mail_resent_from in valors_defecte:
-      logger.info("Tinc parametres adicionals per d'on reenvio %s" % mail_resent_from)
-      parametres_addicionals=valors_defecte[mail_resent_from]      
-    if recipient in valors_defecte:
-      logger.info("Tinc parametres adicionals per on envio %s" % recipient)
-      parametres_addicionals=valors_defecte[recipient]      
-    
+    for header_name in header_order:
+        header_value = self.msg.get_email_header(header_name)
+        if header_value in valors_defecte:
+            logger.info("Tinc parametres adicionals via %s amb valor %s" % (header_name, header_value))
+            parametres_addicionals=valors_defecte[header_value]
+
     return parametres_addicionals
 
   def filtrar(self):

--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -18,12 +18,7 @@ class FiltreNou(Filtre):
     logger.info("UID del solicitant: %s" % self.solicitant)
     return self.solicitant!=None
 
-  def filtrar(self):
-    logger.info("Aplico filtre...")
-    body=self.msg.get_body()
-    subject=self.msg.get_subject()
-    if len(subject)==0:
-      subject="Ticket de %s" % self.solicitant
+  def obtenir_parametres_addicionals(self):
     recipient=self.msg.get_to()
     mail_from=self.msg.get_from()
     mail_resent_from=self.msg.get_resent_from()
@@ -42,6 +37,16 @@ class FiltreNou(Filtre):
       logger.info("Tinc parametres adicionals per on envio %s" % recipient)
       parametres_addicionals=valors_defecte[recipient]      
     
+    return parametres_addicionals
+
+  def filtrar(self):
+    logger.info("Aplico filtre...")
+    body=self.msg.get_body()
+    subject=self.msg.get_subject()
+    if len(subject)==0:
+      subject="Ticket de %s" % self.solicitant
+
+    parametres_addicionals=self.obtenir_parametres_addicionals()
     logger.info("Poso equip resolutor %s" % parametres_addicionals['equipResolutor'])
     logger.info("A veure si puc crear el ticket de %s" % self.solicitant)
     descripcio=("[Tiquet creat des del correu de %s del %s a les %s]<br><br>" % 

--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -19,18 +19,16 @@ class FiltreNou(Filtre):
     return self.solicitant!=None
 
   def obtenir_parametres_addicionals(self):
-    header_order=[ 'From', 'Resent-From', 'To' ]
+    header_order=[ 'To', 'Resent-From', 'From' ]
     valors_defecte=settings.get("valors_defecte")
-    equip_resolutor_nous=settings.get("equip_resolutor_nous")
-    parametres_addicionals={"equipResolutor":equip_resolutor_nous}
 
     for header_name in header_order:
         header_value = self.msg.get_email_header(header_name)
         if header_value in valors_defecte:
             logger.info("Tinc parametres adicionals via %s amb valor %s" % (header_name, header_value))
-            parametres_addicionals=valors_defecte[header_value]
+            return valors_defecte[header_value]
 
-    return parametres_addicionals
+    return { "equipResolutor": settings.get("equip_resolutor_nous") }
 
   def filtrar(self):
     logger.info("Aplico filtre...")

--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -19,14 +19,12 @@ class FiltreNou(Filtre):
     return self.solicitant!=None
 
   def obtenir_parametres_addicionals(self):
-    header_order=[ 'To', 'Resent-From', 'From' ]
-    valors_defecte=settings.get("valors_defecte")
-
-    for header_name in header_order:
-        header_value = self.msg.get_email_header(header_name)
-        if header_value in valors_defecte:
-            logger.info("Tinc parametres adicionals via %s amb valor %s" % (header_name, header_value))
-            return valors_defecte[header_value]
+    for item in settings.get("valors_defecte"):
+        for header_name in item['order']:
+            header_value = self.msg.get_email_header(header_name)
+            if header_value == item['match']:
+                logger.info("Tinc parametres adicionals via %s amb valor %s" % (header_name, header_value))
+                return item['defaults']
 
     return { "equipResolutor": settings.get("equip_resolutor_nous") }
 

--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -1,6 +1,7 @@
 import time
 from filtres.filtre import Filtre
 import settings
+import re
 
 import logging
 logger = logging.getLogger(__name__)
@@ -20,9 +21,10 @@ class FiltreNou(Filtre):
 
   def obtenir_parametres_addicionals(self):
     for item in settings.get("valors_defecte"):
+        regex = re.compile(item['match'])
         for header_name in item['order']:
             header_value = self.msg.get_email_header(header_name)
-            if header_value == item['match']:
+            if header_value and regex.match(header_value):
                 logger.info("Tinc parametres adicionals via %s amb valor %s" % (header_name, header_value))
                 return item['defaults']
 

--- a/settings_sample.py
+++ b/settings_sample.py
@@ -33,21 +33,21 @@ settings={
   "valors_defecte":[
     {
       "order": ['To','Resent-From','From'],
-      "match": "webmaster@meudomini.upc.edu",
+      "match": "^webmaster@meudomini\.upc\.edu$",
       "defaults": {
         "equipResolutor": "11111"
       }
     },
     {
       "order": ['To','Resent-From','From'],
-      "match": "jaumem@fib.upc.edu",
+      "match": "^jaumem@fib\.upc\.edu$",
       "defaults": {
         "equipResolutor": "11112"
       }
     },
     {
       "order": ['To','Resent-From','From'],
-      "match": "jaume.moral@upc.edu",
+      "match": "^jaume\.moral@upc\.edu$",
       "defaults": {
         "equipResolutor": "11113"
       }

--- a/settings_sample.py
+++ b/settings_sample.py
@@ -30,11 +30,29 @@ settings={
   # Valors amb els que creem els tickets dependent de l'adreça a la qual hem enviat el mail
   # A part de l'equipResolutor, es poden canviar tots els paramatres documentats al servei
   # SOA de creació de tickets (prioritat, tipus...)
-  "valors_defecte":{
-    "webmaster@meudomini.upc.edu": {"equipResolutor":"11111"},
-    "jaumem@fib.upc.edu": {"equipResolutor":"11112"},
-    "jaume.moral@upc.edu": {"equipResolutor":"11113"}
-  },
+  "valors_defecte":[
+    {
+      "order": ['To','Resent-From','From'],
+      "match": "webmaster@meudomini.upc.edu",
+      "defaults": {
+        "equipResolutor": "11111"
+      }
+    },
+    {
+      "order": ['To','Resent-From','From'],
+      "match": "jaumem@fib.upc.edu",
+      "defaults": {
+        "equipResolutor": "11112"
+      }
+    },
+    {
+      "order": ['To','Resent-From','From'],
+      "match": "jaume.moral@upc.edu",
+      "defaults": {
+        "equipResolutor": "11113"
+      }
+    }
+  ],
 
   # Filtrs actius. També podem utilitzar 
   # - filtres.reply_reobrint.FiltreRepyReobrint (que reobre tickets tancats)


### PR DESCRIPTION
Proposta esmentada a #45 per fer més explícit el comportament del filtre per a tiquets nous que tria valors per defecte segons algunes capçaleres del correu:

* Les capçaleres a tractar són part de la configuració, per tant se'n poden triar d'altres.
* Els valors a buscar són expressions regulars.
* S'avaluen les condicions en ordre i es retornen els valors per defecte de la primera que casa.

La configuració de l'exemple és l'equivalent a la que hi havia anteriorment, amb les capçaleres que s'utilitzaven implícitament en el codi de la classe FiltreNou.