### PR TITLE
Afegeix el virtualenv recomanat al PATH

### DIFF
--- a/mailtoticket.sh
+++ b/mailtoticket.sh
@@ -13,6 +13,10 @@ set -e
 exec >> $0.log 2>&1
 
 cd $HOME/mailtoticket
+
+# Add recommended virtualenv to $PATH
+PATH=$PWD/local/bin:$PATH
+
 python mailtoticket.py \
 | sed -e '2d' -e '0,/^[Mm]essage-[Ii][Dd]:/{//d}' \
 | /usr/sbin/sendmail -oem -i -t


### PR DESCRIPTION
Aquest canvi afegeix el virtualenv al PATH tal com s'ha recomanat al [README](README.md) per assegurar que es trobaran les dependències del programa en el moment de l'execució, independentment del _shell_ que s'utilitzi per cridar l'script.

Per exemple, pot haver-hi diferències entre executar-lo des del _cron_ o des del _shell_.