### PR TITLE
Fix SMTP loops (closes #61)

### DIFF
--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -29,6 +29,7 @@ if __name__ == '__main__':
   if a is not None:
     logger.info("Fitxer de configuracio [%s]",a)
 
+  estat="UNKNOWN"
   tractat=False
   try:
     logger.info("-----------------------------------------------------")
@@ -38,13 +39,16 @@ if __name__ == '__main__':
     if mail.cal_tractar():
       if filtres.aplicar_filtres(mail):
         tractat=True
-        print "x-mailtoticket: afd25dad494b9345fa2e0a34dc2aa4c11594c3e7b672f772a7fa003ad80bd09f045a170213ae2ba4f47eb8043ac61a56e44ff031a014b82f7508bc5543960138"
+        estat="SUCCESS"
         logger.info("Marco el mail com a tractat")
     else:
+      estat="SKIP"
       logger.info("No cal tractar el mail %s" % mail.get_subject_ascii())
   except Exception, e:
+    estat="ERROR"
     logger.exception("Ha petat algun dels filtres i no marco el mail com a tractat")
   finally:
+    print "X-Mailtoticket: %s" % estat
     print mail
     logger.info("-----------------------------------------------------")
     if not tractat and settings.get("notificar_errors"):

--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -41,6 +41,9 @@ if __name__ == '__main__':
         tractat=True
         estat="SUCCESS"
         logger.info("Marco el mail com a tractat")
+      else:
+        estat="REJECT"
+        logger.info("Rebutjo el mail per no passar els filtres")
     else:
       estat="SKIP"
       logger.info("No cal tractar el mail %s" % mail.get_subject_ascii())


### PR DESCRIPTION
Aquest canvi fa que sempre s'afegeixi la capçalera `X-Mailtoticket` al correu sortint perquè es pugui identificar com un correu processat i d'aquesta manera evitar bucles.

Una cosa important a tenir en compte és que ara la capçalera retorna el valor `SUCCESS` quan tot va bé, enlloc del xurro alfanumèric que retornava fins ara. Això afectarà aquelles instàncies que compten amb aquest valor sigui un de determinat en els seus filtres de Maildrop.