### PR TITLE
Afegeixo metode per netejar el bloc de PGP d'un mail

### DIFF
--- a/netejahtml.py
+++ b/netejahtml.py
@@ -87,3 +87,15 @@ def treure_signatura_html(html):
   if len(tags)==1: tags[0].decompose()
   return str(soup)
 
+def treure_pgp(text):
+  pgp=False
+  cos=[]
+  linies=text.split("\n")
+  for l in linies:
+    if re.match("^-----BEGIN PGP PUBLIC KEY BLOCK-----$",l):
+      pgp=True
+    if not pgp:
+      cos.append(l)
+    if re.match("^-----END PGP PUBLIC KEY BLOCK-----$",l):
+      pgp=False
+  return "\n".join(cos)


### PR DESCRIPTION
Als testos ja tenia un mail amb un bloc PGP, aixi que he afegit una nova operacio a netejahtml per esborrar aquests blocs i un test per comprovar que ho fa correcte.

Els metodes de netejar HTML encara no s'utilitzen al mailtoticket, s'ha de veure quina seria la millor forma de que siguin configurables