### PR TITLE
Permeto attachments sense filename que no siguin imatges

### DIFF
--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -38,6 +38,11 @@ class FiltreNou(Filtre):
     if len(subject)==0:
       subject="Ticket de %s" % self.solicitant
 
+    if self.msg.get_reply_to()!=None:
+      from_or_reply_to=self.msg.get_reply_to()
+    else:
+      from_or_reply_to=self.msg.get_from()
+      
     parametres_addicionals=self.obtenir_parametres_addicionals()
     logger.info("A veure si puc crear el ticket de %s" % self.solicitant)
     descripcio=("[Tiquet creat des del correu de %s del %s a les %s]<br><br>" %
@@ -46,6 +51,7 @@ class FiltreNou(Filtre):
     resultat=self.tickets.alta_tiquet(
       assumpte=subject,
       solicitant=self.solicitant,
+      emailSolicitant=from_or_reply_to,
       descripcio=descripcio,
       **parametres_addicionals
       )
@@ -58,11 +64,6 @@ class FiltreNou(Filtre):
     ticket_id=resultat['codiTiquet']
     descripcio=self.afegir_attachments_canviant_body(ticket_id,self.solicitant,descripcio)
     logger.info("Attachments (si n'hi ha) afegits")
-
-    if self.msg.get_reply_to()!=None:
-      from_or_reply_to=self.msg.get_reply_to()
-    else:
-      from_or_reply_to=self.msg.get_from()
 
     if settings.get("assignar_data_resolucio_amb_data_creacio"):
       data_resolucio=time.strftime("%d-%m-%Y")

--- a/mailticket.py
+++ b/mailticket.py
@@ -147,16 +147,11 @@ class MailTicket:
     if attachment.is_multipart():
       return False
 
-    ctype=attachment.get_content_type()
     filename=attachment.get_filename()
     contingut=attachment.get_payload()
 
-    # Si no tenim filename, nomes pot ser una imatge incrustada
-    if filename==None:
-      if ctype not in ['image/jpeg','image/png','image/gif']:
-        return False
-    # I si tenim filename, que no sigui un dels que filtrem
-    else:
+    # Si tenim filename, que no sigui un dels que filtrem
+    if filename!=None:
       for f in self.filtrar_attachments_per_nom:
         p=re.compile(f)
         if p.match(filename):

--- a/soa/tiquets.py
+++ b/soa/tiquets.py
@@ -62,6 +62,7 @@ class GestioTiquets(SOAService):
       self.password_gn6,
       self.domini,
       solicitant,
+      emailSolicitant,
       client,
       assumpte,
       descripcio,

--- a/soa/tiquets.py
+++ b/soa/tiquets.py
@@ -4,7 +4,7 @@ import settings
 class GestioTiquets(SOAService):
 
   def __init__(self):
-    self.url="https://bus-soa.upc.edu/gN6/GestioTiquetsv4?wsdl"
+    self.url="https://bus-soa.upc.edu/gN6/GestioTiquetsv5?wsdl"
     self.username_gn6=settings.get("username_gn6")
     self.password_gn6=settings.get("password_gn6")
     self.domini=settings.get("domini")
@@ -62,7 +62,7 @@ class GestioTiquets(SOAService):
       self.password_gn6,
       self.domini,
       solicitant,
-      #emailSolicitant,
+      emailSolicitant,
       client,
       assumpte,
       descripcio,

--- a/soa/tiquets.py
+++ b/soa/tiquets.py
@@ -4,7 +4,7 @@ import settings
 class GestioTiquets(SOAService):
 
   def __init__(self):
-    self.url="https://bus-soa.upc.edu/gN6/GestioTiquetsv5?wsdl"
+    self.url="https://bus-soa.upc.edu/gN6/GestioTiquetsv4?wsdl"
     self.username_gn6=settings.get("username_gn6")
     self.password_gn6=settings.get("password_gn6")
     self.domini=settings.get("domini")
@@ -62,7 +62,7 @@ class GestioTiquets(SOAService):
       self.password_gn6,
       self.domini,
       solicitant,
-      emailSolicitant,
+      #emailSolicitant,
       client,
       assumpte,
       descripcio,

--- a/soa/tiquets.py
+++ b/soa/tiquets.py
@@ -4,7 +4,7 @@ import settings
 class GestioTiquets(SOAService):
 
   def __init__(self):
-    self.url="https://bus-soa.upc.edu/gN6/GestioTiquetsv4?wsdl"
+    self.url="https://bus-soa.upc.edu/gN6/GestioTiquetsv5?wsdl"
     self.username_gn6=settings.get("username_gn6")
     self.password_gn6=settings.get("password_gn6")
     self.domini=settings.get("domini")
@@ -39,6 +39,7 @@ class GestioTiquets(SOAService):
 
   def alta_tiquet(self,
     solicitant,
+    emailSolicitant='',
     client='',
     assumpte='',
     descripcio='',


### PR DESCRIPTION
He descobert que un dels test no passava. Un dels mails de prova te un altre mail com a attachment. Aquest mail attachat te part text i part html. Per tant, el mail original té 2 attachments.

Mailtoticket es menjava els attachments perque no considerava possible tenir un attachment sense un nom de fitxer que no fos una imatge. He tret aquesta comprovació perque era innecessaria.