### PR TITLE
Permeto attachments sense filename que no siguin imatges

### DIFF
--- a/mailticket.py
+++ b/mailticket.py
@@ -147,16 +147,11 @@ class MailTicket:
     if attachment.is_multipart():
       return False
 
-    ctype=attachment.get_content_type()
     filename=attachment.get_filename()
     contingut=attachment.get_payload()
 
-    # Si no tenim filename, nomes pot ser una imatge incrustada
-    if filename==None:
-      if ctype not in ['image/jpeg','image/png','image/gif']:
-        return False
-    # I si tenim filename, que no sigui un dels que filtrem
-    else:
+    # Si tenim filename, que no sigui un dels que filtrem
+    if filename!=None:
       for f in self.filtrar_attachments_per_nom:
         p=re.compile(f)
         if p.match(filename):


### PR DESCRIPTION
He descobert que un dels test no passava. Un dels mails de prova te un altre mail com a attachment. Aquest mail attachat te part text i part html. Per tant, el mail original té 2 attachments.

Mailtoticket es menjava els attachments perque no considerava possible tenir un attachment sense un nom de fitxer que no fos una imatge. He tret aquesta comprovació perque era innecessaria.


Per ser 100% puristes, el mail hauria de tenir un sol attachment, ja que es tracta d'un multipart alternative. Aixo implicaria canviar el tractament que faig dels alternatives, pero crec que un canvi prou radical com per començar amb aquest petit canvi que com a minim fa que no es perdi informació al tractar el mail.