### PR TITLE
Attach original mail

### DIFF
--- a/correu.py
+++ b/correu.py
@@ -1,19 +1,30 @@
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.mime.message import MIMEMessage
 import smtplib
 import settings
 import logging
 logger = logging.getLogger(__name__)
 
-def enviar(text):
+def enviar(text, orig):
   try:
+    msgid=orig['Message-Id']
     de=settings.get("notificar_errors_from");
     a=settings.get("notificar_errors_to");
     host=settings.get("servidor_mail");
     subject="Informe d'errors de MailToTicket"
+    msg = MIMEMultipart('mixed')
+    msg['Subject'] = subject
+    msg['From'] = de
+    msg['To'] = a
+    part1 = MIMEText(text, 'plain')
+    part2 = MIMEMessage(orig, 'rfc822')
+    msg.attach(part1)
+    msg.attach(part2)
     server = smtplib.SMTP(host, 25)
-    text_ascii=text.encode('ascii','ignore')
-    msg = "From: %s\nTo: %s\nSubject:%s\n\n%s" % (de,a,subject,text_ascii)
-    server.sendmail(de, a, msg)
-    logger.info("Informe d'errors enviat per mail")
+    server.sendmail(de, a, msg.as_string())
+    server.quit()
+    logger.info("Informe d'errors de %s enviat per correu" % msgid)
   except Exception, e:
     logger.info(e)
-    logger.info("No s'ha pogut enviar l'informe d'error per correu")
+    logger.info("No s'ha pogut enviar per correu l'informe d'errors de %s" % msgid)

--- a/correu.py
+++ b/correu.py
@@ -3,7 +3,7 @@ import settings
 import logging
 logger = logging.getLogger(__name__)
 
-def enviar(text):	
+def enviar(text):
   try:
     de=settings.get("notificar_errors_from");
     a=settings.get("notificar_errors_to");

--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -64,5 +64,5 @@ if __name__ == '__main__':
     print mail
     logger.info("-----------------------------------------------------")
     if not tractat and settings.get("notificar_errors"):
-      correu.enviar(buffer_logs.getvalue())
+      correu.enviar(buffer_logs.getvalue(), mail.msg)
     sys.exit(codi_sortida(estat))


### PR DESCRIPTION
Adjunta el correu original als informes d'error i a més a més indica en els logs quin és el `Message-Id` tant si ha pogut enviar-lo com en cas contrari.

Resol #54.