### PR TITLE
Evita que avorti si mailtoticket.py dóna error

### DIFF
--- a/mailtoticket.sh
+++ b/mailtoticket.sh
@@ -9,7 +9,6 @@
 #   Cyrus IMAP server may ignore duplicates).
 #
 
-set -e
 exec >> $0.log 2>&1
 
 cd $HOME/mailtoticket


### PR DESCRIPTION
Amb la introducció dels codis de sortida no té sentit forçar
que el mailtoticket.sh avorti si falla qualsevol ordre que
s'executi. Abans ho utilitzàvem per detectar si no es trobava
el sendmail o el $HOME.