### PR TITLE
Reduïr codi duplicat a FiltreNou i FiltreReply

### DIFF
--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -61,7 +61,7 @@ class FiltreNou(Filtre):
     parametres.update(parametres_addicionals)        
     resultat=self.tickets.alta_tiquet(**parametres)
 
-    if self.resultat_erroni(resultat):
+    if self.tickets.resultat_erroni(resultat):
       logger.info("Error: %s - %s" % (resultat['codiRetorn'],resultat['descripcioError']))
       return False
     logger.info("Ticket creat")
@@ -88,6 +88,3 @@ class FiltreNou(Filtre):
       logger.info("Mail modificat a %s" % self.msg.get_from())
 
     return True
-
-  def resultat_erroni(self, resultat):
-      return resultat['codiRetorn'] != "1"

--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -82,7 +82,7 @@ class FiltreNou(Filtre):
       dataResol=data_resolucio
       )
 
-    if resultat['codiRetorn']!="1":
+    if self.tickets.resultat_erroni(resultat):
       logger.info("Error: %s - %s" % (resultat['codiRetorn'],resultat['descripcioError']))
     else:
       logger.info("Mail modificat a %s" % self.msg.get_from())

--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -4,6 +4,7 @@ import settings
 import re
 
 import logging
+from soa.service import SOAService
 logger = logging.getLogger(__name__)
 
 class FiltreNou(Filtre):
@@ -61,8 +62,8 @@ class FiltreNou(Filtre):
     parametres.update(parametres_addicionals)        
     resultat=self.tickets.alta_tiquet(**parametres)
 
-    if self.tickets.resultat_erroni(resultat):
-      logger.info(self.tickets.retorna_missatge_error(resultat))
+    if SOAService.resultat_erroni(resultat):
+      logger.info(SOAService.retorna_missatge_error(resultat))
       return False
     logger.info("Ticket creat")
 

--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -62,7 +62,7 @@ class FiltreNou(Filtre):
     resultat=self.tickets.alta_tiquet(**parametres)
 
     if self.tickets.resultat_erroni(resultat):
-      logger.info("Error: %s - %s" % (resultat['codiRetorn'],resultat['descripcioError']))
+      logger.info(self.tickets.retorna_missatge_error(resultat))
       return False
     logger.info("Ticket creat")
 
@@ -83,7 +83,7 @@ class FiltreNou(Filtre):
       )
 
     if self.tickets.resultat_erroni(resultat):
-      logger.info("Error: %s - %s" % (resultat['codiRetorn'],resultat['descripcioError']))
+      logger.info(self.tickets.retorna_missatge_error(resultat))
     else:
       logger.info("Mail modificat a %s" % self.msg.get_from())
 

--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -61,7 +61,7 @@ class FiltreNou(Filtre):
     parametres.update(parametres_addicionals)        
     resultat=self.tickets.alta_tiquet(**parametres)
 
-    if resultat['codiRetorn']!="1":
+    if self.resultat_erroni(resultat):
       logger.info("Error: %s - %s" % (resultat['codiRetorn'],resultat['descripcioError']))
       return False
     logger.info("Ticket creat")
@@ -88,3 +88,6 @@ class FiltreNou(Filtre):
       logger.info("Mail modificat a %s" % self.msg.get_from())
 
     return True
+
+  def resultat_erroni(self, resultat):
+      return resultat['codiRetorn'] != "1"

--- a/filtres/reply.py
+++ b/filtres/reply.py
@@ -3,6 +3,7 @@ from filtres.filtre import Filtre
 import settings
 
 import logging
+from soa.service import SOAService
 logger = logging.getLogger(__name__)
 
 class FiltreReply(Filtre):
@@ -72,8 +73,8 @@ class FiltreReply(Filtre):
       tipusComentari='COMENT_TIQUET_PRIVAT' if self.privat else 'COMENT_TIQUET_PUBLIC',
       esNotificat=notificat if not self.privat else 'N')
 
-    if self.tickets.resultat_erroni(resultat):
-      logger.info(self.tickets.retorna_missatge_error(resultat))
+    if SOAService.resultat_erroni(resultat):
+      logger.info(SOAService.retorna_missatge_error(resultat))
       return False
 
     logger.info("Comentari afegit")

--- a/filtres/reply.py
+++ b/filtres/reply.py
@@ -73,11 +73,8 @@ class FiltreReply(Filtre):
       esNotificat=notificat if not self.privat else 'N')
 
     if self.tickets.resultat_erroni(resultat):
-      logger.info(self.retorna_missatge_error(resultat))
+      logger.info(self.tickets.retorna_missatge_error(resultat))
       return False
 
     logger.info("Comentari afegit")
     return True
-
-  def retorna_missatge_error(self, resultat):
-    return "Error: %s - %s" % (resultat['codiRetorn'], resultat['descripcioError'])

--- a/filtres/reply.py
+++ b/filtres/reply.py
@@ -72,7 +72,7 @@ class FiltreReply(Filtre):
       tipusComentari='COMENT_TIQUET_PRIVAT' if self.privat else 'COMENT_TIQUET_PUBLIC',
       esNotificat=notificat if not self.privat else 'N')
 
-    if resultat['codiRetorn']!="1":
+    if self.tickets.resultat_erroni(resultat):
       logger.info("Error: %s - %s" % (resultat['codiRetorn'],resultat['descripcioError']))
       return False
 

--- a/filtres/reply.py
+++ b/filtres/reply.py
@@ -73,8 +73,11 @@ class FiltreReply(Filtre):
       esNotificat=notificat if not self.privat else 'N')
 
     if self.tickets.resultat_erroni(resultat):
-      logger.info("Error: %s - %s" % (resultat['codiRetorn'],resultat['descripcioError']))
+      logger.info(self.retorna_missatge_error(resultat))
       return False
 
     logger.info("Comentari afegit")
     return True
+
+  def retorna_missatge_error(self, resultat):
+    return "Error: %s - %s" % (resultat['codiRetorn'], resultat['descripcioError'])

--- a/soa/identitat.py
+++ b/soa/identitat.py
@@ -44,7 +44,7 @@ class GestioIdentitat(SOAService):
       return uid
 
 
-class GestioIdentitatLocal(SOAService):
+class GestioIdentitatLocal:
 
   def __init__(self):
     self.mails_addicionals=settings.get("mails_addicionals")

--- a/soa/identitat.py
+++ b/soa/identitat.py
@@ -44,7 +44,7 @@ class GestioIdentitat(SOAService):
       return uid
 
 
-class GestioIdentitatLocal:
+class GestioIdentitatLocal(SOAService):
 
   def __init__(self):
     self.mails_addicionals=settings.get("mails_addicionals")

--- a/soa/service.py
+++ b/soa/service.py
@@ -14,8 +14,10 @@ class SOAService(object):
             UsernameToken(self.username_soa, self.password_soa))
         self.client.set_options(wsse=security)
 
-    def resultat_erroni(self, resultat):
+    @staticmethod
+    def resultat_erroni(resultat):
         return resultat['codiRetorn'] != "1"
 
-    def retorna_missatge_error(self, resultat):
+    @staticmethod
+    def retorna_missatge_error(resultat):
         return "Error: %s - %s" % (resultat['codiRetorn'], resultat['descripcioError'])

--- a/soa/service.py
+++ b/soa/service.py
@@ -13,3 +13,6 @@ class SOAService(object):
         security.tokens.append(
             UsernameToken(self.username_soa, self.password_soa))
         self.client.set_options(wsse=security)
+
+    def resultat_erroni(self, resultat):
+        return resultat['codiRetorn'] != "1"

--- a/soa/service.py
+++ b/soa/service.py
@@ -2,12 +2,14 @@ from suds.wsse import Security, UsernameToken
 from suds.client import Client
 import settings
 
+
 class SOAService(object):
 
-  def __init__(self):
-    self.username_soa=settings.get("username_soa")
-    self.password_soa=settings.get("password_soa")
-    self.client=Client(self.url)
-    security = Security()
-    security.tokens.append(UsernameToken(self.username_soa,self.password_soa))
-    self.client.set_options(wsse=security)
+    def __init__(self):
+        self.username_soa = settings.get("username_soa")
+        self.password_soa = settings.get("password_soa")
+        self.client = Client(self.url)
+        security = Security()
+        security.tokens.append(
+            UsernameToken(self.username_soa, self.password_soa))
+        self.client.set_options(wsse=security)

--- a/soa/service.py
+++ b/soa/service.py
@@ -16,3 +16,6 @@ class SOAService(object):
 
     def resultat_erroni(self, resultat):
         return resultat['codiRetorn'] != "1"
+
+    def retorna_missatge_error(self, resultat):
+        return "Error: %s - %s" % (resultat['codiRetorn'], resultat['descripcioError'])

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -1,0 +1,23 @@
+import unittest
+
+from soa.identitat import GestioIdentitatLocal
+
+
+class TestService(unittest.TestCase):
+    
+    service = GestioIdentitatLocal()
+
+    def test_resultat_erroni_true(self):
+        resultat = {'codiRetorn': "2"}
+        self.assertTrue(self.service.resultat_erroni(resultat))
+        
+    def test_resultat_erroni_false(self):
+        resultat = {'codiRetorn': "1"}
+        self.assertFalse(self.service.resultat_erroni(resultat))
+        
+    def test_retorna_missatge_error(self):
+        resultat = {'codiRetorn': "2", 'descripcioError': 'peta'}
+        self.assertEquals("Error: 2 - peta", self.service.retorna_missatge_error(resultat))
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -1,23 +1,21 @@
 import unittest
-
-from soa.identitat import GestioIdentitatLocal
+from soa.service import SOAService
 
 
 class TestService(unittest.TestCase):
-    
-    service = GestioIdentitatLocal()
 
     def test_resultat_erroni_true(self):
         resultat = {'codiRetorn': "2"}
-        self.assertTrue(self.service.resultat_erroni(resultat))
-        
+        self.assertTrue(SOAService.resultat_erroni(resultat))
+
     def test_resultat_erroni_false(self):
         resultat = {'codiRetorn': "1"}
-        self.assertFalse(self.service.resultat_erroni(resultat))
-        
+        self.assertFalse(SOAService.resultat_erroni(resultat))
+
     def test_retorna_missatge_error(self):
         resultat = {'codiRetorn': "2", 'descripcioError': 'peta'}
-        self.assertEquals("Error: 2 - peta", self.service.retorna_missatge_error(resultat))
-        
+        self.assertEquals(
+            "Error: 2 - peta", SOAService.retorna_missatge_error(resultat))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Per als tests unitaris que hem creat per a la classe SOAService, necessitariem que la classe `GestioIdentitatLocal` (que aprofitem com a mock per als tests) hereti de SOAService.
Abans d'acceptar el PR, necessitem que en Jaume ens confirmi que això és acceptable (vegeu commit f11ab65).
En concret, ens cal saber si podem canviar la linia 

    class GestioIdentitatLocal:

per

    class GestioIdentitatLocal(SOAService):
