### PR TITLE
Actualitzo a sintaxi recomenada de 'except'

### DIFF
--- a/correu.py
+++ b/correu.py
@@ -26,7 +26,7 @@ def enviar(text, orig):
         server.sendmail(de, a, msg.as_string())
         server.quit()
         logger.info("Informe d'errors de %s enviat per correu" % msgid)
-    except Exception, e:
+    except Exception as e:
         logger.info(e)
         logger.info("No s'ha pogut enviar per correu l'informe d'errors de %s"
                     % msgid)

--- a/filtres/reply.py
+++ b/filtres/reply.py
@@ -52,7 +52,7 @@ class FiltreReply(Filtre):
             logger.info("Crearem comentari a nom de %s" % self.solicitant)
             return True
 
-        except Exception, e:
+        except Exception as e:
             logger.info("Peta el filtre... %s" % str(e))
             return False
 

--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
         else:
             estat = SKIP
             logger.info("No cal tractar el mail %s" % mail.get_subject_ascii())
-    except Exception, e:
+    except Exception as e:
         estat = ERROR
         logger.exception(
             "Ha petat algun dels filtres i no marco el mail com a tractat"


### PR DESCRIPTION
A partir d'uns avisos del CodeClimate hem detectat que fem servir
en alguns fitxers la sintaxi 'except E, e', que està desaconsellada
a partir de python 2.6. Es recomana canviar-la per 'except E as e'.
Més detalls a http://stackoverflow.com/a/2535770/1314986