### PR TITLE
Encapsulament de la comprovació d'errors SOA

### DIFF
--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -69,7 +69,7 @@ class FiltreNou(Filtre):
         parametres.update(parametres_addicionals)
         resultat = self.tickets.alta_tiquet(**parametres)
 
-        if self.tickets.resultat_erroni(resultat):
+        if SOAService.resultat_erroni(resultat):
             logger.info("Error: %s - %s" % (
                 resultat['codiRetorn'],
                 resultat['descripcioError']
@@ -98,7 +98,7 @@ class FiltreNou(Filtre):
             dataResol=data_resolucio
         )
 
-        if self.tickets.resultat_erroni(resultat):
+        if SOAService.resultat_erroni(resultat):
             logger.info("Error: %s - %s" % (
                 resultat['codiRetorn'],
                 resultat['descripcioError']

--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -69,7 +69,7 @@ class FiltreNou(Filtre):
         parametres.update(parametres_addicionals)
         resultat = self.tickets.alta_tiquet(**parametres)
 
-        if self.resultat_erroni(resultat):
+        if self.tickets.resultat_erroni(resultat):
             logger.info("Error: %s - %s" % (
                 resultat['codiRetorn'],
                 resultat['descripcioError']
@@ -98,7 +98,7 @@ class FiltreNou(Filtre):
             dataResol=data_resolucio
         )
 
-        if self.resultat_erroni(resultat):
+        if self.tickets.resultat_erroni(resultat):
             logger.info("Error: %s - %s" % (
                 resultat['codiRetorn'],
                 resultat['descripcioError']
@@ -107,6 +107,3 @@ class FiltreNou(Filtre):
             logger.info("Mail modificat a %s" % self.msg.get_from())
 
         return True
-
-    def resultat_erroni(self, resultat):
-        return resultat['codiRetorn'] != "1"

--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -69,7 +69,7 @@ class FiltreNou(Filtre):
         parametres.update(parametres_addicionals)
         resultat = self.tickets.alta_tiquet(**parametres)
 
-        if resultat['codiRetorn'] != "1":
+        if self.resultat_erroni(resultat):
             logger.info("Error: %s - %s" % (
                 resultat['codiRetorn'],
                 resultat['descripcioError']
@@ -98,7 +98,7 @@ class FiltreNou(Filtre):
             dataResol=data_resolucio
         )
 
-        if resultat['codiRetorn'] != "1":
+        if self.resultat_erroni(resultat):
             logger.info("Error: %s - %s" % (
                 resultat['codiRetorn'],
                 resultat['descripcioError']
@@ -107,3 +107,6 @@ class FiltreNou(Filtre):
             logger.info("Mail modificat a %s" % self.msg.get_from())
 
         return True
+
+    def resultat_erroni(self, resultat):
+        return resultat['codiRetorn'] != "1"

--- a/filtres/reply.py
+++ b/filtres/reply.py
@@ -87,7 +87,7 @@ class FiltreReply(Filtre):
             esNotificat=notificat if not self.privat else 'N'
         )
 
-        if self.resultat_erroni(resultat):
+        if self.tickets.resultat_erroni(resultat):
             logger.info("Error: %s - %s" % (
                 resultat['codiRetorn'],
                 resultat['descripcioError']
@@ -96,6 +96,3 @@ class FiltreReply(Filtre):
 
         logger.info("Comentari afegit")
         return True
-
-    def resultat_erroni(self, resultat):
-        return resultat['codiRetorn'] != "1"

--- a/filtres/reply.py
+++ b/filtres/reply.py
@@ -87,7 +87,7 @@ class FiltreReply(Filtre):
             esNotificat=notificat if not self.privat else 'N'
         )
 
-        if resultat['codiRetorn'] != "1":
+        if self.resultat_erroni(resultat):
             logger.info("Error: %s - %s" % (
                 resultat['codiRetorn'],
                 resultat['descripcioError']
@@ -96,3 +96,6 @@ class FiltreReply(Filtre):
 
         logger.info("Comentari afegit")
         return True
+
+    def resultat_erroni(self, resultat):
+        return resultat['codiRetorn'] != "1"

--- a/filtres/reply.py
+++ b/filtres/reply.py
@@ -87,7 +87,7 @@ class FiltreReply(Filtre):
             esNotificat=notificat if not self.privat else 'N'
         )
 
-        if self.tickets.resultat_erroni(resultat):
+        if SOAService.resultat_erroni(resultat):
             logger.info("Error: %s - %s" % (
                 resultat['codiRetorn'],
                 resultat['descripcioError']

--- a/soa/service.py
+++ b/soa/service.py
@@ -14,5 +14,6 @@ class SOAService(object):
                 UsernameToken(self.username_soa, self.password_soa))
         self.client.set_options(wsse=security)
 
-    def resultat_erroni(self, resultat):
+    @staticmethod
+    def resultat_erroni(resultat):
         return resultat['codiRetorn'] != "1"

--- a/soa/service.py
+++ b/soa/service.py
@@ -13,3 +13,6 @@ class SOAService(object):
         security.tokens.append(
                 UsernameToken(self.username_soa, self.password_soa))
         self.client.set_options(wsse=security)
+
+    def resultat_erroni(self, resultat):
+        return resultat['codiRetorn'] != "1"

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -1,0 +1,16 @@
+import unittest
+from soa.service import SOAService
+
+
+class TestService(unittest.TestCase):
+
+    def test_resultat_erroni_true(self):
+        resultat = {'codiRetorn': "2"}
+        self.assertTrue(SOAService.resultat_erroni(resultat))
+
+    def test_resultat_erroni_false(self):
+        resultat = {'codiRetorn': "1"}
+        self.assertFalse(SOAService.resultat_erroni(resultat))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
L'objectiu d'aquesta branca és començar a encapsular l'estructura interna del resultat d'una crida a SOA, que actualment es comprova amb l'expressió `resultat['codiRetorn']`.

Aquest PR encapsula l'ús duplicat d'aquesta expressió que hem detectat en els warnings del CodeClimate, en els següents fitxers: 

 * `filtres/nou.py` (línies 72 i 101)
 * `filtres/reply.py` (línia 90)

La refactorització implica encapsular l'expressió actual en un nou mètode `resultat_erroni` que estarà definit en un únic lloc (la classe `SOAService`).