### PR TITLE
Configurar CodeClimate per forçar python 2

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,6 +12,8 @@ engines:
     enabled: true
   radon:
     enabled: true
+    config:
+      python_version: 2
   pep8:
     enabled: true
 ratings:


### PR DESCRIPTION
Configurem l'engine 'radon' per a què comprovi la sintaxi de
Python 2, ja que per omissió comprova la de Python 3.

Veure l'apartat "Python Version" de la documentació de
CodeClimate: https://docs.codeclimate.com/docs/radon