### PR TITLE
Utilitza la URL pública del repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Instal·lació
 La forma recomanada d'instal·lació és dins d'un _virtualenv_ de Python per poder gestionar les dependències sense permisos d'administrador:
 
 ```
-git clone git@github.com:UPC/mailtoticket.git
+git clone https://github.com/UPC/mailtoticket.git
 cd mailtoticket
 virtualenv local
 echo "PATH=$PWD/local/bin:\$PATH" >> ~/.bashrc


### PR DESCRIPTION
Havíem posat la URL via ssh, que només serveix per a les persones que tenen accés d'escriptura al repo. És millor posar la URL via https i en tot cas, qui vulgui ssh ja sap com fer-ho.