### PR TITLE
Append message header cleanly

### DIFF
--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
             "Ha petat algun dels filtres i no marco el mail com a tractat"
         )
     finally:
-        print "X-Mailtoticket: %s" % estat
+        mail.msg['X-Mailtoticket'] = estat
         print mail
         logger.info("-----------------------------------------------------")
         if not tractat and settings.get("notificar_errors"):


### PR DESCRIPTION
Avoids breaking message format when using procmail or other
MDA having each message starting with 'From ' (à la mbox),
as reported in #26.