### PR TITLE
Afegeixo un setter al config per poder canviar paràmetres ja carregats

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -19,3 +19,8 @@ def get(clau):
         return settings[clau]
     except:
         return None
+
+
+def set(clau, valor):
+    global settings
+    settings[clau] = valor


### PR DESCRIPTION
Als ultims testos s'ha fet un canvi de paràmetre de configuració per un test concret accedint directament a l'objecte settings. Funciona, pero Eclipse es queixa de que la variable no està visible.
Hem afegit un "set" a la configuració per poder canviar-ho de forma més elegant i per ser coherents amb el "get" que tenim per accedir al valor d'un paràmetre.

Faig també una PR als testos amb el canvi corresponent.