### PR TITLE
Fix string concatenation

### DIFF
--- a/filtres/reply_reobrint.py
+++ b/filtres/reply_reobrint.py
@@ -21,7 +21,7 @@ class FiltreReplyReobrint(FiltreReply):
             self.ticket = self.tickets.consulta_tiquet(codi=self.ticket_id)
             if self.ticket['estat'] == 'TIQUET_STATUS_TANCAT':
                 logger.info(
-                    "No podem reobrir el ticket %s." +
+                    "No podem reobrir el ticket %s."
                     "El filtre no es aplicable" % self.ticket_id
                 )
                 return False

--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     logging.basicConfig(
         filename=settings.get("log_file"),
         level=settings.get("log_level"),
-        format='%(asctime)s [%(process)d] %(name)-12s' +
+        format='%(asctime)s [%(process)d] %(name)-12s'
         ' %(levelname)-8s %(message)s'
     )
 


### PR DESCRIPTION
Combining string formats and concatenation with the + operator
brings errors like this:

```
TypeError: not all arguments converted during string formatting
```