### PR TITLE
Support regexes in mails_no_ticket

### DIFF
--- a/mailticket.py
+++ b/mailticket.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import email
 import hashlib
 import base64
@@ -200,8 +202,17 @@ class MailTicket:
     def te_attachments(self):
         return len(self.get_attachments()) > 0
 
+    def comprova_mails_no_ticket(self):
+        for item in self.mails_no_ticket:
+            # Considera una regex si comença amb circumflex
+            regex = item if item[0] is '^' else '^' + re.escape(item) + '$'
+            if re.compile(regex, re.UNICODE).match(self.get_from()):
+                return True
+
+        return False
+
     def cal_tractar(self):
-        if self.get_from() in self.mails_no_ticket:
+        if self.comprova_mails_no_ticket():
             return False
 
         if self.msg.get_content_type() == "multipart/report":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4
 bleach
-mock
+mock>=1.3.0
 suds
 discover

--- a/settings.py
+++ b/settings.py
@@ -24,3 +24,8 @@ def get(clau):
 def set(clau, valor):
     global settings
     settings[clau] = valor
+
+
+def init():
+    global settings
+    settings = {}

--- a/settings_sample.py
+++ b/settings_sample.py
@@ -88,7 +88,8 @@ settings = {
 
     # Correus dels que no s'ha de crear cap tiquet per la raó que sigui
     "mails_no_ticket": [
-        "info.exemple@upc.edu"
+        "info.exemple@upc.edu",
+        "^.*@example\.com$",
     ],
 
     # Filtres d'adjunts que no s'han de processar (per exemple, les

--- a/test/test_mailticket.py
+++ b/test/test_mailticket.py
@@ -1,4 +1,5 @@
 import unittest
+import settings
 from mock import patch, mock_open
 from mailticket import MailTicket
 import __builtin__
@@ -7,6 +8,7 @@ import __builtin__
 class TestMailTicket(unittest.TestCase):
 
     def setUp(self):
+        settings.init()
         with patch.object(__builtin__, 'open',
                           mock_open(read_data="From: foo@example.com\n\n")):
             with open('foo') as fp:

--- a/test/test_mailticket.py
+++ b/test/test_mailticket.py
@@ -1,0 +1,32 @@
+import unittest
+from mock import patch, mock_open
+from mailticket import MailTicket
+import __builtin__
+
+
+class TestMailTicket(unittest.TestCase):
+
+    def setUp(self):
+        with patch.object(__builtin__, 'open',
+                          mock_open(read_data="From: foo@example.com\n\n")):
+            with open('foo') as fp:
+                self.mail = MailTicket(fp)
+
+    def test_mails_no_ticket_0001(self):
+        self.mail.mails_no_ticket = ["foo@example.com"]
+        self.assertFalse(self.mail.cal_tractar())
+
+    def test_mails_no_ticket_0002(self):
+        self.mail.mails_no_ticket = ["bar@example.com"]
+        self.assertTrue(self.mail.cal_tractar())
+
+    def test_mails_no_ticket_0003(self):
+        self.mail.mails_no_ticket = ['^.*@domain\.tld$']
+        self.assertTrue(self.mail.cal_tractar())
+
+    def test_mails_no_ticket_0004(self):
+        self.mail.mails_no_ticket = ['^.*@example\.com$']
+        self.assertFalse(self.mail.cal_tractar())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add support for regexes in `mails_no_ticket` setting while preserving old plain strings compatibility.

Closes #108 