### PR TITLE
Tenim en compte el mail del ticket quan tractem un reply

### DIFF
--- a/filtres/reply.py
+++ b/filtres/reply.py
@@ -33,8 +33,8 @@ class FiltreReply(Filtre):
                 logger.info("El comentari es privat")
                 self.privat = True
 
-            # Mirem si es un ticket valid
-            self.ticket = self.tickets.consulta_tiquet(codi=self.ticket_id)
+            # Obtenim el tiquet amb les dades de solicitant i emailSolicitant
+            self.ticket = self.tickets.consulta_tiquet_dades(self.ticket_id)
 
             # Mirem qui ha creat el ticket
             self.solicitant_segons_ticket = self.ticket['solicitant']
@@ -48,6 +48,8 @@ class FiltreReply(Filtre):
             # Si no trobem el mail, sera de l'usuari generic
             if self.solicitant_segons_mail is not None:
                 self.solicitant = self.solicitant_segons_mail
+            elif self.ticket['emailSolicitant'] == self.msg.get_from():
+                self.solicitant = self.solicitant_segons_ticket
             else:
                 self.solicitant = settings.get("usuari_extern")
 
@@ -60,7 +62,7 @@ class FiltreReply(Filtre):
 
     def filtrar(self):
         body = self.msg.get_body()
-        if self.solicitant_segons_mail == self.solicitant_segons_ticket:
+        if self.solicitant == self.solicitant_segons_ticket:
             notificat = 'N'
         else:
             notificat = 'S'

--- a/soa/tiquets.py
+++ b/soa/tiquets.py
@@ -71,6 +71,10 @@ class GestioTiquets(SOAService):
         )
         return resultat['llistaTiquets']
 
+    def consulta_tiquet_dades(self, codi):
+        resultat = self.consulta_tiquets_dades(codi=codi)
+        return resultat[0]
+
     def afegir_comentari_tiquet(self, **kwargs):
         resultat = self.client.service.AfegirComentariTiquet(
             username=self.username_gn6,

--- a/test/test_reply.py
+++ b/test/test_reply.py
@@ -1,0 +1,47 @@
+import unittest
+import mock
+import settings
+from soa.tiquets import GestioTiquets
+from soa.identitat import GestioIdentitat
+from filtres.reply import FiltreReply
+from mailticket import MailTicket
+
+
+class TestReply(unittest.TestCase):
+
+    def setUp(self):
+        self.tickets = mock.create_autospec(GestioTiquets)
+        self.tickets.consulta_tiquet_dades.return_value = {
+            "solicitant": "usuari.real",
+            "emailSolicitant": "mail.extern@mail.com"
+        }
+        self.identitat = mock.create_autospec(GestioIdentitat)
+        self.identitat.obtenir_uid.return_value = None
+
+        settings.init()
+        settings.set("regex_reply", "(.*)")  # Una que trobi sempre algo
+        settings.set("regex_privat", "X")   # Una que no trobi mai res
+        settings.set("usuari_extern", "usuari.extern")
+
+    def test_reply_mail_extern_igual_a_solicitant_detecta_usuari_real(
+            self):
+        msg = mock.create_autospec(MailTicket)
+        msg.get_from.return_value = "mail.extern@mail.com"
+        msg.get_subject.return_value = "Re: ticket de prova"
+        f = FiltreReply(msg, self.tickets, self.identitat)
+
+        self.assertTrue(f.es_aplicable())
+        self.assertEquals(f.solicitant, 'usuari.real')
+
+    def test_reply_mail_extern_diferent_a_solicitant_detecta_usuari_extern(
+            self):
+        msg = mock.create_autospec(MailTicket)
+        msg.get_from.return_value = "mail.extern.diferent@mail.com"
+        msg.get_subject.return_value = "Re: ticket de prova"
+        f = FiltreReply(msg, self.tickets, self.identitat)
+
+        self.assertTrue(f.es_aplicable())
+        self.assertEquals(f.solicitant, 'usuari.extern')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Tractem el cas d'un comentari d'un usuari que te un ticket creat amb un mail diferent del seu oficial i que contesta des d'aquest mail.

Si aquest usuari fa un reply des d'aquet mail no conegut, quedava fins ara com a usuari extern i se li enviava una notificació. Ara detectem que es tracta del mateix usuari perque coincideix el mail i per tant no queda com a extern i no cal enviar-li notificació.