### PR TITLE
Si identitat no respon amb un camp emailPreferent, no ha de petar

### DIFF
--- a/soa/identitat.py
+++ b/soa/identitat.py
@@ -42,8 +42,11 @@ class GestioIdentitat(SOAService):
                 for persona in resultat.llistaPersones.persona:
                     dades_persona = self.client.service.obtenirDadesPersona(
                         commonName=persona.cn)
-                    if (self.canonicalitzar_mail(
-                            dades_persona.emailPreferent) == mail):
+                    emailPreferent = getattr(
+                        dades_persona,
+                        'emailPreferent',
+                        None)
+                    if (self.canonicalitzar_mail(emailPreferent) == mail):
                         uid = persona.cn
                         return uid
 


### PR DESCRIPTION
Fem que si no existeix, retorni com a valor per defecte None.

Tot el problema es que quan estem buscant a quin usuari correspon una adreça, busquem de totes les seves identitats quina es la que te l'adreça com a adreça preferent. El problema es que hi ha identitats que no tenen ni mail i aixo fa petar la cerca sense retornar cap usuari.