### PR TITLE
Canvis per primer mirar si la part anterior a @upc.edu es un usuari real

### DIFF
--- a/soa/identitat.py
+++ b/soa/identitat.py
@@ -31,6 +31,9 @@ class GestioIdentitat(SOAService):
 
     def obtenir_uid_remot(self, mail):
         try:
+            # Pot ser que un usuari d'un departament no tingui a identitat
+            # digital un mail del tipus @upc.edu, aixi que primer comprovem
+            # si la part esquerra del mail correspon a un usuari UPC real
             if "@upc.edu" in mail:
                 cn = mail.split("@")[0]
                 dades_persona = self.client.service.obtenirDadesPersona(
@@ -38,6 +41,8 @@ class GestioIdentitat(SOAService):
                 if dades_persona.ok:
                     return cn
 
+            # Si no hi ha correspondencia directa amb un usuari UPC
+            # busquem a partir del mail qui pot ser
             resultat = self.client.service.llistaPersones(email=mail)
             if len(resultat.llistaPersones.persona) == 1:
                 # Quan tenim un resultat, es aquest

--- a/soa/identitat.py
+++ b/soa/identitat.py
@@ -30,12 +30,18 @@ class GestioIdentitat(SOAService):
         return uid
 
     def obtenir_uid_remot(self, mail):
-        uid = None
         try:
+            if "@upc.edu" in mail:
+                cn = mail.split("@")[0]
+                dades_persona = self.client.service.obtenirDadesPersona(
+                    commonName=cn)
+                if dades_persona.ok:
+                    return cn
+
             resultat = self.client.service.llistaPersones(email=mail)
             if len(resultat.llistaPersones.persona) == 1:
                 # Quan tenim un resultat, es aquest
-                uid = resultat.llistaPersones.persona[0].cn
+                return resultat.llistaPersones.persona[0].cn
             else:
                 # Si tenim mes d'un, busquem el que te el mail que busquem
                 # com a preferent o be retornem el primer
@@ -47,15 +53,11 @@ class GestioIdentitat(SOAService):
                         'emailPreferent',
                         None)
                     if (self.canonicalitzar_mail(emailPreferent) == mail):
-                        uid = persona.cn
-                        return uid
+                        return persona.cn
 
-                if uid is None:
-                    uid = resultat.llistaPersones.persona[0].cn
+                return None
         except:
-            uid = None
-        finally:
-            return uid
+            return None
 
 
 class GestioIdentitatLocal:


### PR DESCRIPTION
He canviat bastant la forma com obtenim un mail remot per que la gent que té mails de departament no té normalment els seus mails upc registrats a identitat digital.

Hem trobat el cas d'una persona que només tenia el seu compte upc en un compte genèric que havia demanat (i que no es el seu) aixi que per evitar aixo primer mirem pels mails @upc.edu si la part de l'esquerra correspon a un usuari i si es aixi, es aquest i punt.

En cas contrari, continuem amb el que feiem fins ara, pero sent mes agressius i retornant "None" en cas de no detectar cap email preferent quan hi ha més d'una persona.