### PR TITLE
Afegim l'encoding quan enviem un mail per evitar problemes amb accents

### DIFF
--- a/correu.py
+++ b/correu.py
@@ -18,7 +18,7 @@ def enviar(text, orig):
         msg['Subject'] = subject
         msg['From'] = de
         msg['To'] = a
-        part1 = MIMEText(text, 'plain')
+        part1 = MIMEText(text, 'plain', 'utf8')
         part2 = MIMEMessage(orig, 'rfc822')
         msg.attach(part1)
         msg.attach(part2)


### PR DESCRIPTION
Quan en els logs hi havia accents (per exemple, perque apareixen al subject o al codi d'error que retorna el bus SOA) el correu no es podia enviar. Si especifiquem la codificació, evitem aquest problema