### PR TITLE
Skip Auto-Submitted messages (e.g. vacation)

### DIFF
--- a/mailticket.py
+++ b/mailticket.py
@@ -214,23 +214,25 @@ class MailTicket:
 
         return False
 
+    # La capçalera Auto-Submitted hauria de caçar la majoria de
+    # missatges automàtics que respectin els estàndards (e.g.
+    # vacation, postmaster notify, undelivered mail, returned
+    # mail, etc.).
+    #
+    # Les altres condicions segurament no siguin necessàries
+    # perquè en la majoria de casos la primera caçarà el missatge.
+    def es_missatge_automatic(self):
+        return self.get_email_header('Auto-Submitted') is not None \
+            or self.msg.get_content_type() == "multipart/report" \
+            or "Return Receipt" in self.get_body() \
+            or "DELIVERY FAILURE" in self.get_subject() \
+            or "Informe de lectura" in self.get_subject()
+
     def cal_tractar(self):
         if self.comprova_mails_no_ticket():
             return False
 
-        if self.msg.get_content_type() == "multipart/report":
-            return False
-
-        if "Return Receipt" in self.get_body():
-            return False
-
-        if "DELIVERY FAILURE" in self.get_subject():
-            return False
-
-        if "Informe de lectura" in self.get_subject():
-            return False
-
-        if self.get_email_header('Auto-Submitted') is not None:
+        if self.es_missatge_automatic():
             return False
 
         return True

--- a/mailticket.py
+++ b/mailticket.py
@@ -230,6 +230,9 @@ class MailTicket:
         if "Informe de lectura" in self.get_subject():
             return False
 
+        if self.get_email_header('Auto-Submitted') is not None:
+            return False
+
         return True
 
     def __str__(self):

--- a/test/mails/mailauto.txt
+++ b/test/mails/mailauto.txt
@@ -1,0 +1,6 @@
+Subject: mail auto-submitted
+Auto-Submitted: foobar
+MIME-Version: 1.0
+Content-Type: text/plain
+
+This is an auto-submitted message.

--- a/test/test_mailticket.py
+++ b/test/test_mailticket.py
@@ -40,6 +40,12 @@ class TestMailTicket(unittest.TestCase):
         body = mail_buit.get_body()
         self.assertEquals("", body)
 
+    def test_get_auto_submitted(self):
+        mail_buit = llegir_mail("mailbuit.txt")
+        mail_auto = llegir_mail("mailauto.txt")
+        self.assertTrue(mail_auto.es_missatge_automatic())
+        self.assertFalse(mail_buit.es_missatge_automatic())
+
     @freeze_time("2015-09-11 09:45", tz_offset=+2)
     def test_get_date_invalid_format(self):
         # Un missatge amb la data en format "Apple Mail"


### PR DESCRIPTION
Al DAC hem detectat que les respostes automàtiques del vacation de sieve es processaven com a tiquets nous i hem fet aquest petit canvi que evita que aquests correus es processin.

Abans d'acceptar la proposta de canvi, m'agradaria afegir algun test i una mica més de documentació. Creo la proposta ara per veure si passa els tests però ja avisaré quan estigui llesta per integrar amb master.
