### PR TITLE
Acceptar mails amb capçalera «Date» en format no estàndard

### DIFF
--- a/mailticket.py
+++ b/mailticket.py
@@ -121,8 +121,9 @@ class MailTicket:
             aux = datetime.datetime.fromtimestamp(timestamp)
             return aux
         except:
-            logger.debug("No puc parsejar la data!")
-            return None
+            logger.debug(
+                "Format de data no estàndard; es retorna la data actual.")
+            return datetime.datetime.today()
 
     def get_to(self):
         to = parseaddr(self.msg['To'])[1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ bleach
 mock>=1.3.0
 suds
 discover
+freezegun

--- a/test/test_mailticket.py
+++ b/test/test_mailticket.py
@@ -1,11 +1,10 @@
 import unittest
 import settings
 import datetime
-import freezegun
 from mock import patch, mock_open
 from mailticket import MailTicket
 import __builtin__
-from freezegun.api import freeze_time
+from freezegun import freeze_time
 
 
 class TestMailTicket(unittest.TestCase):

--- a/test/test_mailticket.py
+++ b/test/test_mailticket.py
@@ -34,7 +34,7 @@ class TestMailTicket(unittest.TestCase):
 
     def test_get_date(self):
         d = self.mail.get_date()
-        self.assertEquals("28/09/2016 10:24", d.strftime("%d/%m/%Y %H:%M"))
+        self.assertIsInstance(d, datetime.datetime)
 
     def test_get_date_invalid_format(self):
         # Un missatge amb la data en format "Apple Mail"

--- a/test/test_mailticket.py
+++ b/test/test_mailticket.py
@@ -1,5 +1,6 @@
 import unittest
 import settings
+import datetime
 from mock import patch, mock_open
 from mailticket import MailTicket
 import __builtin__
@@ -9,8 +10,9 @@ class TestMailTicket(unittest.TestCase):
 
     def setUp(self):
         settings.init()
-        with patch.object(__builtin__, 'open',
-                          mock_open(read_data="From: foo@example.com\n\n")):
+        data = "From: foo@example.com\n" \
+               "Date: Tue, 28 Sep 2016 10:24:09 +0200 (CEST)\n\n"
+        with patch.object(__builtin__, 'open', mock_open(read_data=data)):
             with open('foo') as fp:
                 self.mail = MailTicket(fp)
 
@@ -29,6 +31,19 @@ class TestMailTicket(unittest.TestCase):
     def test_mails_no_ticket_0004(self):
         self.mail.mails_no_ticket = ['^.*@example\.com$']
         self.assertFalse(self.mail.cal_tractar())
+
+    def test_get_date(self):
+        d = self.mail.get_date()
+        self.assertEquals("28/09/2016 10:24", d.strftime("%d/%m/%Y %H:%M"))
+
+    def test_get_date_invalid_format(self):
+        # Un missatge amb la data en format "Apple Mail"
+        data = "Date: 9/23/2016 11:04:10 AM\n\n"
+        with patch.object(__builtin__, 'open', mock_open(read_data=data)):
+            with open('foo') as fp:
+                apple_mail = MailTicket(fp)
+
+        self.assertIsInstance(apple_mail.get_date(), datetime.datetime)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_mailticket.py
+++ b/test/test_mailticket.py
@@ -1,9 +1,11 @@
 import unittest
 import settings
 import datetime
+import freezegun
 from mock import patch, mock_open
 from mailticket import MailTicket
 import __builtin__
+from freezegun.api import freeze_time
 
 
 class TestMailTicket(unittest.TestCase):
@@ -36,6 +38,7 @@ class TestMailTicket(unittest.TestCase):
         d = self.mail.get_date()
         self.assertIsInstance(d, datetime.datetime)
 
+    @freeze_time("2015-09-11 09:45", tz_offset=+2)
     def test_get_date_invalid_format(self):
         # Un missatge amb la data en format "Apple Mail"
         data = "Date: 9/23/2016 11:04:10 AM\n\n"
@@ -43,7 +46,8 @@ class TestMailTicket(unittest.TestCase):
             with open('foo') as fp:
                 apple_mail = MailTicket(fp)
 
-        self.assertIsInstance(apple_mail.get_date(), datetime.datetime)
+        dt = apple_mail.get_date()
+        self.assertEquals("11/09/2015 11:45", dt.strftime("%d/%m/%Y %H:%M"))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Quan la capçalera Date està en un format no estàndard, no es crea el tiquet i es genera un informe d'error.

S'ha detectat aquest comportament amb missatges creats amb "Apple Mail". L'error es produeix al mètode MailTicket.get_date().

Com que la data només es fa servir a títol indicatiu, es proposa que, quan MailToTicket no pugui parsejar la data del missatge, es faci servir la data actual del sistema (vegeu https://demana.upc.edu/mailtoticket/tickets.php?id=48).
