### PR TITLE
Si hi ha "reply-to" el mira abans del "from" per trobar el solicitant

### DIFF
--- a/filtres/filtre.py
+++ b/filtres/filtre.py
@@ -27,6 +27,10 @@ class Filtre(object):
         return
 
     def get_uid(self):
+        # Comprovem primer el reply-to pel cas de Prisma en que tenim
+        # un formulari que envia mails com un usuari genèric i amb reply-to
+        # a l'adreça de l'usuari que ha fet la petició.
+        # TODO: intentar fer aixo configurable
         uid = None
         if self.msg.get_reply_to() is not None:
             uid = self.identitat.obtenir_uid(self.msg.get_reply_to())

--- a/filtres/filtre.py
+++ b/filtres/filtre.py
@@ -27,14 +27,12 @@ class Filtre(object):
         return
 
     def get_uid(self):
-        uid = self.identitat.obtenir_uid(self.msg.get_from())
-        if uid is not None:
-            return uid
-
+        uid = None
         if self.msg.get_reply_to() is not None:
-            return self.identitat.obtenir_uid(self.msg.get_reply_to())
-
-        return None
+            uid = self.identitat.obtenir_uid(self.msg.get_reply_to())
+        if uid is None:
+            uid = self.identitat.obtenir_uid(self.msg.get_from())
+        return uid
 
     def codificar_base_64_si_cal(self, attachment):
         if attachment['Content-Transfer-Encoding'] == 'base64':


### PR DESCRIPTION
Tenim un cas d'ús de mail provinent d'un formulari de genweb on el from es un mail genèric i el reply-to es el que ens indica quin es l'usuari.

S'ha canviat el codi per primer mirar si a partir el reply-to podem saber quin usuari es i si existeix, fem servir aquest. Si no, fem servir el del from (que serà el cas habitual)

De fet, estavem fent servir el reply-to com a mail per enviar les notificacions, aixi que es lògic que també el fem servir per calcular l'usuari solicitant.