### PR TITLE
Faltava la capçalera UTF per no tenir problemes amb comentaris

### DIFF
--- a/filtres/filtre.py
+++ b/filtres/filtre.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import base64
 
 import logging


### PR DESCRIPTION
Simplement he vist que des de que he posat el comentari, no se m'executa correctament perque no tenia especificat que era UTF8