### PR TITLE
Feature mails sempre ticket

### DIFF
--- a/test/mails/mailauto.txt
+++ b/test/mails/mailauto.txt
@@ -1,3 +1,4 @@
+From: mail.concret@example.com
 Subject: mail auto-submitted
 Auto-Submitted: foobar
 MIME-Version: 1.0

--- a/test/test_mailticket.py
+++ b/test/test_mailticket.py
@@ -64,6 +64,11 @@ class TestMailTicket(unittest.TestCase):
         body = mail.get_body()
         self.assertTrue("títol" in body)
 
+    def test_mail_sempre_ticket(self):
+        settings.set("mails_sempre_ticket", ["mail.concret@example.com"])
+        mail_auto = llegir_mail("mailauto.txt")
+        self.assertTrue(mail_auto.comprova_mails_sempre_ticket())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Permetro el parametre mails_sempre_ticket, per indicar una llista de mails que han de poder crear ticket encara que estiguin marcats com automàtics

Ja ho havia demanat (i implementat!) en una altra pull request ( #172 ) Haviem trobat una solució externa que al final no ha estat prou flexible. 


