### PR TITLE
Bug sobreescriure email solicitant

### DIFF
--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -23,6 +23,8 @@ class FiltreNou(Filtre):
 
     def obtenir_parametres_addicionals(self):
         defaults = {"equipResolutor": settings.get("equip_resolutor_nous")}
+        if settings.get("valors_defecte") is None:
+            return defaults
         for item in settings.get("valors_defecte"):
             regex = re.compile(item['match'], re.IGNORECASE)
             for header_name in item['order']:
@@ -99,7 +101,6 @@ class FiltreNou(Filtre):
 
         resultat = self.tickets.modificar_tiquet(
             codiTiquet=ticket_id,
-            emailSolicitant=from_or_reply_to,
             descripcio=self.netejar_html(descripcio),
             dataResol=data_resolucio
         )


### PR DESCRIPTION
Quan creem un ticket, en una segona fase modifiquem el ticket. Segons el codi actual, es tornava a modificar l'email solicitant per posar el from_or_reply_to, pero aixo es un error perque quan el ticket es crea, pot ser que sobreescrivim el from_or_reply_to per algun valor per defecte posat al fitxer de configuració.

Per exemple, suposem un mail automàtic "reserves@exemple.com" que sabem que ha de generar un ticket com a "persona@exemple.com". Amb el codi actual, aixo es perdia i el ticket quedaria amb el mail de contacte "reserves@exemple.com"