### PR TITLE
Inicialitza els settings buits si troba el fitxer

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -6,8 +6,11 @@ Abans d'accedir podem carregar la configuracio o agafara la per defecte
 
 def load(module="settings_default"):
     global settings
-    m = __import__(module, "settings")
-    settings = m.settings
+    try:
+        m = __import__(module, "settings")
+        settings = m.settings
+    except:
+        settings = {}
 
 
 def get(clau):


### PR DESCRIPTION
Quan no existeix el fitxer settings_default.py amb els valors
per defecte, els inicialitzem sense cap valor. Això és útil per
als tests, que no necessiten tenir cap valor per defecte.