### PR TITLE
Replace pep8 with pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: "pip install -r requirements.txt"
 # command to check before build
 before_script:
     - "python -m compileall -f ."
-    - "pip install pep8 && pep8 ."
+    - "pip install pycodestyle && pycodestyle ."
     - "python -m unittest discover"
 # build nothing right now
 script: "true"

--- a/check-qa.sh
+++ b/check-qa.sh
@@ -15,8 +15,8 @@ PEP8=$(which pycodestyle)
 if [ -x "$PEP8" ]
 then
 	echo "INFO: Running PEP8 checks"
-	pycodestyle --exclude '.git,local,settings_*' .
-	pycodestyle settings_sample.py
+	$PEP8 --exclude '.git,local,settings_*' .
+	$PEP8 settings_sample.py
 else
 	echo "WARNING! pycodestyle command not found, skipping PEP8 checks."
 fi

--- a/check-qa.sh
+++ b/check-qa.sh
@@ -10,13 +10,13 @@ python -m compileall -f -x '/(local|.git)/' -q .
 python -m unittest discover
 
 # comply with PEP8
-PEP8=$(which pep8)
+PEP8=$(which pycodestyle)
 
 if [ -x "$PEP8" ]
 then
 	echo "INFO: Running PEP8 checks"
-	pep8 --exclude '.git,local,settings_*' .
-	pep8 settings_sample.py
+	pycodestyle --exclude '.git,local,settings_*' .
+	pycodestyle settings_sample.py
 else
-	echo "WARNING! pep8 command not found, skipping PEP8 checks."
+	echo "WARNING! pycodestyle command not found, skipping PEP8 checks."
 fi

--- a/mailticket.py
+++ b/mailticket.py
@@ -62,7 +62,7 @@ class MailTicket:
                             part.get_content_charset(), "ignore")
             else:
                 s = unicode(part.get_payload(decode=True))
-        except:
+        except Exception:
             # Tenim problemes per convertir, aixi que fem el que podem
             s = part.get_payload()
 
@@ -124,7 +124,7 @@ class MailTicket:
             timestamp = mktime_tz(tt)
             aux = datetime.datetime.fromtimestamp(timestamp)
             return aux
-        except:
+        except Exception:
             logger.debug(
                 "Format de data no estàndard; es retorna la data actual.")
             return datetime.datetime.today()
@@ -135,7 +135,7 @@ class MailTicket:
             email = parseaddr(self.msg['Resent-To'])[1]
             if email is None or len(email) == 0:
                 email = to
-        except:
+        except Exception:
             email = to
         finally:
             return email.lower()
@@ -201,7 +201,7 @@ class MailTicket:
                 = hashlib.md5(base64.b64decode(contingut)).hexdigest()
             logger.info("Hash:" + hash_attachment)
             return hash_attachment not in self.filtrar_attachments_per_hash
-        except:
+        except Exception:
             logger.info("Tinc un attachment del que no puc calcular el hash")
 
         return True

--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -21,6 +21,7 @@ UNKNOWN = "UNKNOWN"
 def codi_sortida(estat):
     return (0 if estat == SUCCESS or estat == SKIP else 1)
 
+
 if __name__ == '__main__':
     a = None
     opts, args = getopt.getopt(sys.argv[1:], 'c:')

--- a/netejahtml.py
+++ b/netejahtml.py
@@ -73,7 +73,8 @@ def sanitize(html):
 
 @assegura_contingut
 def compacta_br(html):
-    html = re.sub(r'<br\s*/?>(?:\s*<br\s*/?>)+', '<br/><br/>', html, flags=re.I)
+    html = re.sub(r'<br\s*/?>(?:\s*<br\s*/?>)+', '<br/><br/>', html,
+                  flags=re.I)
     return html
 
 

--- a/netejahtml.py
+++ b/netejahtml.py
@@ -66,20 +66,20 @@ def sanitize(html):
         strip=True
     )
     # Aixo es perque els BR siguin autocontinguts i no interfereixin a l'arbre
-    net = re.sub('<br\s*/?>', '<br/>', net, flags=re.I)
-    net = re.sub('</br\s*>', '', net, flags=re.I)
+    net = re.sub(r'<br\s*/?>', '<br/>', net, flags=re.I)
+    net = re.sub(r'</br\s*>', '', net, flags=re.I)
     return "<body>%s</body>" % net
 
 
 @assegura_contingut
 def compacta_br(html):
-    html = re.sub('<br\s*/?>(?:\s*<br\s*/?>)+', '<br/><br/>', html, flags=re.I)
+    html = re.sub(r'<br\s*/?>(?:\s*<br\s*/?>)+', '<br/><br/>', html, flags=re.I)
     return html
 
 
 @assegura_contingut
 def treure_body(html):
-    html = re.sub('</?body\s*>', '', html, flags=re.I)
+    html = re.sub(r'</?body\s*>', '', html, flags=re.I)
     return html
 
 
@@ -165,9 +165,9 @@ def treure_signatura_text(text):
     blocs = 0
     signatura = False
     cos = []
-    linies = text.split("<br\s*/?>\n")
+    linies = text.split(r"<br\s*/?>\n")
     for l in linies:
-        if re.match("^--\s*$", l):
+        if re.match(r"^--\s*$", l):
             signatura = True
             blocs += 1
 

--- a/settings.py
+++ b/settings.py
@@ -9,7 +9,7 @@ def load(module="settings_default"):
     try:
         m = __import__(module, "settings")
         settings = m.settings
-    except:
+    except Exception:
         settings = {}
 
 
@@ -20,7 +20,7 @@ def get(clau):
     global settings
     try:
         return settings[clau]
-    except:
+    except Exception:
         return None
 
 

--- a/settings_sample.py
+++ b/settings_sample.py
@@ -33,17 +33,17 @@ settings = {
     "valors_defecte": [
         {
             "order": ['Resent-To', 'To'],
-            "match": "^webmaster@unitat\.upc\.edu$",
+            "match": r"^webmaster@unitat\.upc\.edu$",
             "defaults": {"equipResolutor": "11111"}
         },
         {
             "order": ['Resent-From', 'From'],
-            "match": "^nom\.cognom@upc\.edu$",
+            "match": r"^nom\.cognom@upc\.edu$",
             "defaults": {"equipResolutor": "11113"}
         },
         {
             "order": ['Resent-From'],
-            "match": "^nom@unitat\.upc\.edu$",
+            "match": r"^nom@unitat\.upc\.edu$",
             "defaults": {"equipResolutor": "11112"}
         },
         {
@@ -67,11 +67,11 @@ settings = {
     ],
 
     # Patró per detectar el número de tiquet
-    "regex_reply": ".*?R[eEvV]:.*?\[Suport Unitat ([\d]+)\]",
+    "regex_reply": r".*?R[eEvV]:.*?\[Suport Unitat ([\d]+)\]",
 
     # Patró per detectar si es tracta d'un comentari privat
     # (també cal modificar la plantilla corresponent a GN6)
-    "regex_privat": "(?i)\(comentari privat\)",
+    "regex_privat": r"(?i)\(comentari privat\)",
 
     # Correus addicionals propis de cada unitat que no es troben al servei
     # d'Identitat Digital UPC. Per cada correu cal indicar quin usuari li
@@ -85,7 +85,7 @@ settings = {
     # o bé a una referència del propi patró (per exemple, el correu
     # nom.cognom@upc.edu -> nom.cognom).
     "patrons_mail_addicionals": {
-        "^root@([a-z0-9.\-]+\.)?unitat\.upc\.e(s|du)$": "extern.general",
+        r"^root@([a-z0-9.\-]+\.)?unitat\.upc\.e(s|du)$": "extern.general",
         "^(.*)@upc.edu$": "%s",
         "^(.*)@upcnet.es$": "%s"
     },
@@ -93,14 +93,14 @@ settings = {
     # Correus dels que no s'ha de crear cap tiquet per la raó que sigui
     "mails_no_ticket": [
         "info.exemple@upc.edu",
-        "^.*@example\.com$",
+        r"^.*@example\.com$",
     ],
 
     # Filtres d'adjunts que no s'han de processar (per exemple, les
     # signatures que contenen imatges adjuntes). Es poden filtrar
     # pel nom de l'adjunt o per l'emprempta digital en MD5.
     "filtrar_attachments_per_nom": [
-        "paic\d+.jpg"
+        r"paic\d+.jpg"
     ],
 
     "filtrar_attachments_per_hash": [

--- a/soa/identitat.py
+++ b/soa/identitat.py
@@ -61,7 +61,7 @@ class GestioIdentitat(SOAService):
                         return persona.cn
 
                 return None
-        except:
+        except Exception:
             return None
 
 
@@ -82,7 +82,7 @@ class GestioIdentitatLocal:
     def obtenir_uid_de_llista(self, mail):
         try:
             return self.mails_addicionals[mail]
-        except:
+        except Exception:
             return None
 
     def obtenir_uid_de_patrons(self, mail):
@@ -93,9 +93,9 @@ class GestioIdentitatLocal:
                 if m:
                     try:
                         return v % m.group(1)
-                    except:
+                    except Exception:
                         return v
 
             return None
-        except:
+        except Exception:
             return None

--- a/test/test_import.py
+++ b/test/test_import.py
@@ -23,5 +23,6 @@ class TestImport(unittest.TestCase):
     def test_import(self):
         pass
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_mailticket.py
+++ b/test/test_mailticket.py
@@ -24,11 +24,11 @@ class TestMailTicket(unittest.TestCase):
         self.assertTrue(self.mail.cal_tractar())
 
     def test_mails_no_ticket_0003(self):
-        self.mail.mails_no_ticket = ['^.*@domain\.tld$']
+        self.mail.mails_no_ticket = [r'^.*@domain\.tld$']
         self.assertTrue(self.mail.cal_tractar())
 
     def test_mails_no_ticket_0004(self):
-        self.mail.mails_no_ticket = ['^.*@example\.com$']
+        self.mail.mails_no_ticket = [r'^.*@example\.com$']
         self.assertFalse(self.mail.cal_tractar())
 
     def test_get_date(self):

--- a/test/test_neteja.py
+++ b/test/test_neteja.py
@@ -26,5 +26,6 @@ class TestNeteja(unittest.TestCase):
         print net
         self.assertFalse("supportList" in net)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_reply.py
+++ b/test/test_reply.py
@@ -53,5 +53,6 @@ class TestReply(unittest.TestCase):
         self.assertTrue(f.es_aplicable())
         self.assertEquals(f.ticket_id, "657421")
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -12,5 +12,6 @@ class TestService(unittest.TestCase):
         resultat = {'codiRetorn': "1"}
         self.assertFalse(SOAService.resultat_erroni(resultat))
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
pep8 has been renamed to pycodestyle (GitHub issue #466)
Use of the pep8 tool will be removed in a future release.
Please install and use `pycodestyle` instead.