### PR TITLE
Return different exit status for errors

### DIFF
--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -19,11 +19,17 @@ UNKNOWN = "UNKNOWN"
 
 
 def codi_sortida(estat):
-    if estat == SUCCESS or estat == SKIP: return 0
-    if estat == ERROR: return 1
-    if estat == REJECT: return 2
-    if estat == UNKNOWN: return 3
-    return -1 # should not reach
+    if estat == SUCCESS or estat == SKIP:
+        return 0
+    if estat == ERROR:
+        return 1
+    if estat == REJECT:
+        return 2
+    if estat == UNKNOWN:
+        return 3
+
+    # should not reach
+    return -1
 
 
 if __name__ == '__main__':

--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -19,7 +19,11 @@ UNKNOWN = "UNKNOWN"
 
 
 def codi_sortida(estat):
-    return (0 if estat == SUCCESS or estat == SKIP else 1)
+    if estat == SUCCESS or estat == SKIP: return 0
+    if estat == ERROR: return 1
+    if estat == REJECT: return 2
+    if estat == UNKNOWN: return 3
+    return -1 # should not reach
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It may be convenient to know exactly what happened when an error is found, thus exiting with a different exit status for each kind of error.

Since both SUCCESS and SKIP are not considered errors, both keep returning exit status 0. Therefore, this change should not break backwards compatibility with MailToTicket instances running via fetchmail.

Thanks: Oleg Rajnovic (UPCnet)
