### PR TITLE
Feature ldap extern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ instala.sh
 local
 .project
 .pydevproject
+bin/
+include/
+lib/
+share/
+pip-selfcheck.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,4 @@ instala.sh
 local
 .project
 .pydevproject
-bin/
-include/
-lib/
-share/
 pip-selfcheck.json

--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ El comportament del programa és executar una sèrie de filtres sobre el correu 
     *   Crea tiquets per adreces desconegudes amb un usuari predeterminat per configuració.
     *   És una extensió del filtre **Nou**.
 
+Opcional
+--------
+
+És pot configurar una tercera font de dades per comprovar si existeix una adreça en un LDAP extern. Per fer-ho cal afegir al fitxer `settings_default.py` al diccionari de settings la següent configuració:
+
+```
+settings = {
+
+    ...
+    # LDAP Extern config
+    "LDAP_SERVER_URL": "xxx",
+    "LDAP_BIND_USER": "xxx",
+    "LDAP_PASSWORD": "xxx",
+    "LDAP_BASE_SEARCH": "xxx",
+    ...
+}
+```
+
+
 Llicència
 ---------
 

--- a/buscamail.py
+++ b/buscamail.py
@@ -4,7 +4,7 @@ from soa.identitat import GestioIdentitat
 import sys
 
 if len(sys.argv) < 2:
-    print ("Cal posar un email com a paràmetre.")
+    print ("INFO: Cal indicar un correu per fer la cerca. Exemple: ./buscamail test@upc.edu")
     sys.exit()
 
 if __name__ == '__main__':
@@ -12,6 +12,6 @@ if __name__ == '__main__':
     identitat = GestioIdentitat()
     uid = identitat.obtenir_uid(mail)
     if uid:
-        print ("El username associat al email '{}' és: {} ".format(mail, uid))
+        print ("El nom d'usuari associat al correu '{}' és: {} ".format(mail, uid))
     else:
-        print ("No s'ha trobat username per l'email: {}".format(mail))
+        print ("No s'ha trobat cap nom d'usuari per correu indicat: {}".format(mail))

--- a/buscamail.py
+++ b/buscamail.py
@@ -4,7 +4,8 @@ from soa.identitat import GestioIdentitat
 import sys
 
 if len(sys.argv) < 2:
-    print ("INFO: Cal indicar un correu per fer la cerca. Exemple: ./buscamail test@upc.edu")
+    print ("INFO: Cal indicar un correu per fer la cerca. \
+        Exemple: ./buscamail test@upc.edu")
     sys.exit()
 
 if __name__ == '__main__':
@@ -12,6 +13,8 @@ if __name__ == '__main__':
     identitat = GestioIdentitat()
     uid = identitat.obtenir_uid(mail)
     if uid:
-        print ("El nom d'usuari associat al correu '{}' és: {} ".format(mail, uid))
+        print ("El nom d'usuari associat al correu '{}' és: \
+            {} ".format(mail, uid))
     else:
-        print ("No s'ha trobat cap nom d'usuari per correu indicat: {}".format(mail))
+        print ("No s'ha trobat cap nom d'usuari per correu indicat: \
+            {}".format(mail))

--- a/buscamail.py
+++ b/buscamail.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 from soa.identitat import GestioIdentitat
 import sys
 

--- a/buscamail.py
+++ b/buscamail.py
@@ -1,13 +1,17 @@
+# -*- coding: utf-8 -*-
 #!/usr/bin/python
 from soa.identitat import GestioIdentitat
 import sys
 
 if len(sys.argv) < 2:
-    print "Has de posar un mail com a parametre"
+    print ("Cal posar un email com a paràmetre.")
     sys.exit()
 
 if __name__ == '__main__':
     mail = sys.argv[1]
     identitat = GestioIdentitat()
     uid = identitat.obtenir_uid(mail)
-    print "El username associat a aquest mail es:" + uid
+    if uid:
+        print ("El username associat al email '{}' és: {} ".format(mail, uid))
+    else:
+        print ("No s'ha trobat username per l'email: {}".format(mail))

--- a/buscaticket.py
+++ b/buscaticket.py
@@ -1,13 +1,14 @@
+# -*- coding: utf-8 -*-
 #!/usr/bin/python
 from soa.tiquets import GestioTiquets
 import sys
 
 if len(sys.argv) < 2:
-    print "Has de posar un id de ticket com a parametre"
+    print ("Has de posar un id de ticket com a paràmetre.")
     sys.exit()
 
 id_ticket = sys.argv[1]
 tiquets = GestioTiquets()
-print tiquets.username_gn6
+print ("Username: " + tiquets.username_gn6)
 dades = tiquets.consulta_tiquet(id_ticket)
-print dades
+print (dades)

--- a/buscaticket.py
+++ b/buscaticket.py
@@ -4,7 +4,8 @@ from soa.tiquets import GestioTiquets
 import sys
 
 if len(sys.argv) < 2:
-    print ("INFO: Cal indicar un codi de ticket per fer la cerca. Exemple: ./buscaticket.py 950010")
+    print ("INFO: Cal indicar un codi de ticket per fer la cerca. \
+        Exemple: ./buscaticket.py 950010")
     sys.exit()
 
 id_ticket = sys.argv[1]

--- a/buscaticket.py
+++ b/buscaticket.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 from soa.tiquets import GestioTiquets
 import sys
 

--- a/buscaticket.py
+++ b/buscaticket.py
@@ -4,11 +4,11 @@ from soa.tiquets import GestioTiquets
 import sys
 
 if len(sys.argv) < 2:
-    print ("Has de posar un id de ticket com a paràmetre.")
+    print ("INFO: Cal indicar un codi de ticket per fer la cerca. Exemple: ./buscaticket.py 950010")
     sys.exit()
 
 id_ticket = sys.argv[1]
 tiquets = GestioTiquets()
-print ("Username: " + tiquets.username_gn6)
+print ("Ticket " + id_ticket + ". Obert per l'usuari: " + tiquets.username_gn6)
 dades = tiquets.consulta_tiquet(id_ticket)
 print (dades)

--- a/correu.py
+++ b/correu.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.message import MIMEMessage

--- a/correu.py
+++ b/correu.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def enviar(text, orig):
+    """ Envia correu amb la info (es crida des del main)"""
     try:
         msgid = orig['Message-Id']
         de = settings.get("notificar_errors_from")

--- a/filtres/__init__.py
+++ b/filtres/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from soa.tiquets import GestioTiquets
 from soa.identitat import GestioIdentitat
 import settings

--- a/filtres/__init__.py
+++ b/filtres/__init__.py
@@ -26,7 +26,7 @@ def aplicar_filtres(mail, tickets=None, identitat=None):
     Apliquem tots els filtres segons l'ordre definit al settings,
     mirant primer si son aplicables i aplicant despres
     """
-    logger.info("Entro a mailtoticket" + mail.get_subject_ascii())
+    logger.info("Entro a mailtoticket. Subject -> " + mail.get_subject_ascii())
 
     if tickets is None:
         tickets = GestioTiquets()

--- a/filtres/__init__.py
+++ b/filtres/__init__.py
@@ -1,8 +1,6 @@
 from soa.tiquets import GestioTiquets
 from soa.identitat import GestioIdentitat
 import settings
-from filtres.nou import FiltreNou
-from filtres.reply import FiltreReply
 
 import logging
 logger = logging.getLogger(__name__)

--- a/filtres/__init__.py
+++ b/filtres/__init__.py
@@ -10,7 +10,8 @@ logger = logging.getLogger(__name__)
 def get_class(kls):
     """
     Obtenim classe a partir del seu nom en un string
-    http://stackoverflow.com/questions/452969/does-python-have-an-equivalent-to-java-class-forname
+    http://stackoverflow.com/questions/452969/does-python-have-an-equivalent-\
+    to-java-class-forname
     """
     parts = kls.split('.')
     module = ".".join(parts[:-1])
@@ -53,7 +54,8 @@ def aplicar_filtres(mail, tickets=None, identitat=None):
                 logger.info("Ja he fet el que havia de fer. Surto!")
                 return True
             else:
-                logger.warning("Error en aplicar el filtre. Deixem de processar")
+                logger.warning("Error en aplicar el filtre. \
+                    Deixem de processar")
                 return False
 
     if not tractat:

--- a/filtres/__init__.py
+++ b/filtres/__init__.py
@@ -53,7 +53,7 @@ def aplicar_filtres(mail, tickets=None, identitat=None):
                 logger.info("Ja he fet el que havia de fer. Surto!")
                 return True
             else:
-                logger.info("Error en aplicar el filtre. Deixem de processar")
+                logger.warning("Error en aplicar el filtre. Deixem de processar")
                 return False
 
     if not tractat:

--- a/filtres/filtre.py
+++ b/filtres/filtre.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import base64
 
 import logging

--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import time
 from filtres.filtre import Filtre
 import settings

--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -78,7 +78,7 @@ class FiltreNou(Filtre):
         resultat = self.tickets.alta_tiquet(**parametres)
 
         if SOAService.resultat_erroni(resultat):
-            logger.info("Error: %s - %s" % (
+            logger.warning("Error: %s - %s" % (
                 resultat['codiRetorn'],
                 resultat['descripcioError']
             ))
@@ -107,7 +107,7 @@ class FiltreNou(Filtre):
         )
 
         if SOAService.resultat_erroni(resultat):
-            logger.info("Error: %s - %s" % (
+            logger.warning("Error: %s - %s" % (
                 resultat['codiRetorn'],
                 resultat['descripcioError']
             ))

--- a/filtres/nou_extern.py
+++ b/filtres/nou_extern.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from filtres.nou import FiltreNou
 import settings
 

--- a/filtres/reply.py
+++ b/filtres/reply.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import re
 from filtres.filtre import Filtre
 import settings

--- a/filtres/reply.py
+++ b/filtres/reply.py
@@ -27,6 +27,8 @@ class FiltreReply(Filtre):
             logger.info("Trobat ticket %s" % ticket_id)
             return ticket_id
         except Exception as e:
+            logger.info(e)
+            logger.info("Error found")
             return None
 
     def obtenir_ticket_id(self):

--- a/filtres/reply.py
+++ b/filtres/reply.py
@@ -21,7 +21,7 @@ class FiltreReply(Filtre):
 
     def buscar_ticket_id(self, string, regex):
         try:
-            logger.info("Buscant numero a  %s" % string)
+            logger.info("Buscant numero de tiquet a %s" % string)
             p = re.compile(regex, re.UNICODE)
             m = p.match(string)
             ticket_id = m.group(1)
@@ -69,7 +69,7 @@ class FiltreReply(Filtre):
             logger.info("Mail de %s" % self.msg.get_from())
 
             self.solicitant_segons_mail = self.get_uid()
-            logger.info("Solicitant segons Mail %s"
+            logger.info("Solicitant segons mail %s"
                         % self.solicitant_segons_mail)
 
             # Si no trobem el mail, sera de l'usuari generic

--- a/filtres/reply.py
+++ b/filtres/reply.py
@@ -28,8 +28,8 @@ class FiltreReply(Filtre):
             logger.info("Trobat ticket %s" % ticket_id)
             return ticket_id
         except Exception as e:
-            logger.info(e)
-            logger.info("Error found")
+            logger.warning(e)
+            logger.warning("Error found")
             return None
 
     def obtenir_ticket_id(self):
@@ -84,7 +84,7 @@ class FiltreReply(Filtre):
             return True
 
         except Exception as e:
-            logger.info("Peta el filtre... %s" % str(e))
+            logger.warning("Peta el filtre... %s" % str(e))
             return False
 
     def filtrar(self):
@@ -120,7 +120,7 @@ class FiltreReply(Filtre):
         )
 
         if SOAService.resultat_erroni(resultat):
-            logger.info("Error: %s - %s" % (
+            logger.warning("Error: %s - %s" % (
                 resultat['codiRetorn'],
                 resultat['descripcioError']
             ))

--- a/filtres/reply_reobrint.py
+++ b/filtres/reply_reobrint.py
@@ -21,7 +21,7 @@ class FiltreReplyReobrint(FiltreReply):
             )
             self.ticket = self.tickets.consulta_tiquet(codi=self.ticket_id)
             if self.ticket['estat'] == 'TIQUET_STATUS_TANCAT':
-                logger.info(
+                logger.warning(
                     "No podem reobrir el ticket %s. El filtre no es aplicable",
                     self.ticket_id
                 )

--- a/filtres/reply_reobrint.py
+++ b/filtres/reply_reobrint.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from filtres.reply import FiltreReply
 
 import logging

--- a/mailticket.py
+++ b/mailticket.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import email
 import hashlib
 import base64

--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -37,19 +37,23 @@ def codi_sortida(estat):
 
 if __name__ == '__main__':
     a = None
-    parser = optparse.OptionParser(description='Mailtoticket: Eina per aconseguir que els mails \
-enviats a una certa adreça es converteixin automàticament en tickets, aprofitant els \
-serveis web que ja ens proporciona GN6 a tal efecte.')
+    parser = optparse.OptionParser(description='Mailtoticket: Eina per \
+    aconseguir que els mails enviats a una certa adreça es converteixin \
+    automàticament en tickets, aprofitant els serveis web que ja ens \
+    proporciona GN6 a tal efecte.')
 
     parser.add_option('-c',
                       action="store", dest="configfile",
-                      help="Fitxer de configuració amb tots els paràmetres requerits.\n NOTA: Hi ha un exemple al fitxer settings_sample.py.", default="")
+                      help="Fitxer de configuració amb tots els paràmetres \
+                      requerits.\n NOTA: Hi ha un exemple al fitxer \
+                      settings_sample.py.", default="")
 
     options, args = parser.parse_args()
 
     # No file passed in params
     if options.configfile == '':
-        print ("Falta fitxer de configuració com a paràmetre. \n Executar mailtoticket.py -h per mostrar l'ajuda.")
+        print ("Falta fitxer de configuració com a paràmetre. \n Executar \
+            mailtoticket.py -h per mostrar l'ajuda.")
         sys.exit(2)
 
     # Load file with default values
@@ -72,8 +76,6 @@ serveis web que ja ens proporciona GN6 a tal efecte.')
     try:
         logger.info("-----------------------------------------------------")
         logger.info("Llegeixo mail")
-        # fp = open('/var/projects/mailtoticket/test/mails/comentaris.txt', 'r')
-        # mail = MailTicket(fp)  # reads from local file
         mail = MailTicket(sys.stdin)  # Reads from mail queue
         logger.info("Mail de %s llegit amb ID %s"
                     % (mail.get_from(), mail.get_header('message-id')))

--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -4,7 +4,7 @@ from mailticket import MailTicket
 import settings
 import filtres
 import correu
-import optparse
+import argparse
 import sys
 import logging
 from StringIO import StringIO
@@ -37,27 +37,27 @@ def codi_sortida(estat):
 
 if __name__ == '__main__':
     a = None
-    parser = optparse.OptionParser(description='Mailtoticket: Eina per \
+    parser = argparse.ArgumentParser(description='Mailtoticket: Eina per \
     aconseguir que els mails enviats a una certa adreça es converteixin \
     automàticament en tickets, aprofitant els serveis web que ja ens \
     proporciona GN6 a tal efecte.')
 
-    parser.add_option('-c',
-                      action="store", dest="configfile",
-                      help="Fitxer de configuració amb tots els paràmetres \
+    parser.add_argument('-c',
+                        action="store", dest="configfile",
+                        help="Fitxer de configuració amb tots els paràmetres \
                       requerits.\n NOTA: Hi ha un exemple al fitxer \
                       settings_sample.py.", default="")
 
-    options, args = parser.parse_args()
+    args = parser.parse_args()
 
     # No file passed in params
-    if options.configfile == '':
+    if args.configfile == '':
         print ("Falta fitxer de configuració com a paràmetre. \n Executar \
             mailtoticket.py -h per mostrar l'ajuda.")
         sys.exit(2)
 
     # Load file with default values
-    settings.load(options.configfile.split('.')[0])
+    settings.load(args.configfile.split('.')[0])
 
     logging.basicConfig(
         filename=settings.get("log_file"),
@@ -69,7 +69,7 @@ if __name__ == '__main__':
     buffer_logs = StringIO()
     logger.addHandler(logging.StreamHandler(buffer_logs))
 
-    logger.info("Fitxer de configuració [%s]", options.configfile)
+    logger.info("Fitxer de configuració [%s]", args.configfile)
 
     estat = UNKNOWN
     tractat = False

--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -72,9 +72,9 @@ serveis web que ja ens proporciona GN6 a tal efecte.')
     try:
         logger.info("-----------------------------------------------------")
         logger.info("Llegeixo mail")
-        fp = open('/var/projects/mailtoticket/test/mails/comentaris.txt', 'r')
-        # mail = MailTicket(sys.stdin) # Reads from mail queue
-        mail = MailTicket(fp)  # reads from local file
+        # fp = open('/var/projects/mailtoticket/test/mails/comentaris.txt', 'r')
+        # mail = MailTicket(fp)  # reads from local file
+        mail = MailTicket(sys.stdin)  # Reads from mail queue
         logger.info("Mail de %s llegit amb ID %s"
                     % (mail.get_from(), mail.get_header('message-id')))
         if mail.cal_tractar():

--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -5,7 +5,6 @@ import settings
 import filtres
 import correu
 import optparse
-import ldap
 import sys
 import logging
 from StringIO import StringIO
@@ -38,29 +37,23 @@ def codi_sortida(estat):
 
 if __name__ == '__main__':
     a = None
-    parser = optparse.OptionParser(description='Mailtoticket! Genera un correu al GN6')
+    parser = optparse.OptionParser(description='Mailtoticket: Eina per aconseguir que els mails \
+enviats a una certa adreça es converteixin automàticament en tickets, aprofitant els \
+serveis web que ja ens proporciona GN6 a tal efecte.')
+
     parser.add_option('-c',
                       action="store", dest="configfile",
-                      help="Configuration file with all the params (like settings_default.py)", default="")
+                      help="Fitxer de configuració amb tots els paràmetres requerits.\n NOTA: Hi ha un exemple al fitxer settings_sample.py.", default="")
 
     options, args = parser.parse_args()
 
     # No file passed in params
     if options.configfile == '':
+        print ("Falta fitxer de configuració com a paràmetre. \n Executar mailtoticket.py -h per mostrar l'ajuda.")
         sys.exit(2)
 
     # Load file with default values
     settings.load(options.configfile.split('.')[0])
-
-    # ldap_server = ldap.initialize('ldap://ldapserver')
-    # username = "uid=user.test,ou=People,dc=mydotcom,dc=com"
-    # password = "my password"
-    # try:
-    #     ldap_server.protocol_version = ldap.VERSION3
-    #     ldap_server.simple_bind_s(username, password)
-    #     valid = True
-    # except Exception, error:
-    #     print error
 
     logging.basicConfig(
         filename=settings.get("log_file"),
@@ -72,14 +65,16 @@ if __name__ == '__main__':
     buffer_logs = StringIO()
     logger.addHandler(logging.StreamHandler(buffer_logs))
 
-    logger.info("Fitxer de configuracio [%s]", options.configfile)
+    logger.info("Fitxer de configuració [%s]", options.configfile)
 
     estat = UNKNOWN
     tractat = False
     try:
         logger.info("-----------------------------------------------------")
         logger.info("Llegeixo mail")
-        mail = MailTicket(sys.stdin)
+        fp = open('/var/projects/mailtoticket/test/mails/comentaris.txt', 'r')
+        # mail = MailTicket(sys.stdin) # Reads from mail queue
+        mail = MailTicket(fp)  # reads from local file
         logger.info("Mail de %s llegit amb ID %s"
                     % (mail.get_from(), mail.get_header('message-id')))
         if mail.cal_tractar():

--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 from mailticket import MailTicket
 import settings
 import filtres

--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -4,11 +4,14 @@ from mailticket import MailTicket
 import settings
 import filtres
 import correu
-
+import optparse
+import ldap
 import sys
-import getopt
 import logging
 from StringIO import StringIO
+
+reload(sys)
+sys.setdefaultencoding('utf-8')
 
 logger = logging.getLogger()
 
@@ -35,10 +38,29 @@ def codi_sortida(estat):
 
 if __name__ == '__main__':
     a = None
-    opts, args = getopt.getopt(sys.argv[1:], 'c:')
-    for o, a in opts:
-        if o == '-c':
-            settings.load(a)
+    parser = optparse.OptionParser(description='Mailtoticket! Genera un correu al GN6')
+    parser.add_option('-c',
+                      action="store", dest="configfile",
+                      help="Configuration file with all the params (like settings_default.py)", default="")
+
+    options, args = parser.parse_args()
+
+    # No file passed in params
+    if options.configfile == '':
+        sys.exit(2)
+
+    # Load file with default values
+    settings.load(options.configfile.split('.')[0])
+
+    # ldap_server = ldap.initialize('ldap://ldapserver')
+    # username = "uid=user.test,ou=People,dc=mydotcom,dc=com"
+    # password = "my password"
+    # try:
+    #     ldap_server.protocol_version = ldap.VERSION3
+    #     ldap_server.simple_bind_s(username, password)
+    #     valid = True
+    # except Exception, error:
+    #     print error
 
     logging.basicConfig(
         filename=settings.get("log_file"),
@@ -50,8 +72,7 @@ if __name__ == '__main__':
     buffer_logs = StringIO()
     logger.addHandler(logging.StreamHandler(buffer_logs))
 
-    if a is not None:
-        logger.info("Fitxer de configuracio [%s]", a)
+    logger.info("Fitxer de configuracio [%s]", options.configfile)
 
     estat = UNKNOWN
     tractat = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ suds
 discover
 freezegun
 requests
-
+python-ldap

--- a/settings.py
+++ b/settings.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 El modul de settings s'importa i s'accedeix als valors amb settings.get("clau")
 Abans d'accedir podem carregar la configuracio o agafara la per defecte

--- a/settings.py
+++ b/settings.py
@@ -10,9 +10,9 @@ def load(module="settings_default"):
     try:
         m = __import__(module, "settings")
     except ImportError:
-        raise SystemExit('Error! No file with configurations found: settings_default.py')
+        raise SystemExit('ERROR: No es troba el fitxer de configuració.')
     except Exception:
-        raise SystemExit('Error! File found, but error in settings. Addapt settings_sample.py file to your custom settings_default.py')
+        raise SystemExit('ERROR: Error al fitxer de configuració, algún paràmetre no és correcte.')
 
 def get(clau):
     if 'settings' not in globals():

--- a/settings.py
+++ b/settings.py
@@ -12,8 +12,7 @@ def load(module="settings_default"):
     except ImportError:
         raise SystemExit('Error! No file with configurations found: settings_default.py')
     except Exception:
-        raise SystemExit('Error! File found, but error in settings. Check settings_sample.py file')
-
+        raise SystemExit('Error! File found, but error in settings. Addapt settings_sample.py file to your custom settings_default.py')
 
 def get(clau):
     if 'settings' not in globals():

--- a/settings.py
+++ b/settings.py
@@ -8,9 +8,10 @@ def load(module="settings_default"):
     global settings
     try:
         m = __import__(module, "settings")
-        settings = m.settings
+    except ImportError:
+        raise SystemExit('Error! No file with configurations found: settings_default.py')
     except Exception:
-        settings = {}
+        raise SystemExit('Error! File found, but error in settings. Check settings_sample.py file')
 
 
 def get(clau):

--- a/settings.py
+++ b/settings.py
@@ -12,7 +12,9 @@ def load(module="settings_default"):
     except ImportError:
         raise SystemExit('ERROR: No es troba el fitxer de configuració.')
     except Exception:
-        raise SystemExit('ERROR: Error al fitxer de configuració, algún paràmetre no és correcte.')
+        raise SystemExit('ERROR: Error al fitxer de configuració, algún \
+            paràmetre no és correcte.')
+
 
 def get(clau):
     if 'settings' not in globals():

--- a/settings_sample.py
+++ b/settings_sample.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
 import tempfile
-import os
 
 # Utilitzeu això si voleu fer servir diverses instàncies a la mateixa
 # maquina. Cada una necessita el seu directori temporal:

--- a/settings_sample.py
+++ b/settings_sample.py
@@ -15,6 +15,10 @@ settings = {
     "username_gn6": "xxx",
     "password_gn6": "xxx",
     "identitat_digital_apikey": "xxx",
+    "LDAP_SERVER_URL": "xxx",
+    "LDAP_BIND_USER": "xxx",
+    "LDAP_PASSWORD": "xxx",
+    "LDAP_BASE_SEARCH": "xxx",
 
     # Instància de GN6 on voleu crear els tiquets
     "domini": "999",

--- a/settings_sample.py
+++ b/settings_sample.py
@@ -5,6 +5,8 @@ import tempfile
 # Utilitzeu això si voleu fer servir diverses instàncies a la mateixa
 # maquina. Cada una necessita el seu directori temporal:
 #
+# import os
+#
 # tempfile.tempdir = os.environ['HOME'] + "/tmp"
 
 settings = {

--- a/settings_sample.py
+++ b/settings_sample.py
@@ -15,10 +15,6 @@ settings = {
     "username_gn6": "xxx",
     "password_gn6": "xxx",
     "identitat_digital_apikey": "xxx",
-    "LDAP_SERVER_URL": "xxx",
-    "LDAP_BIND_USER": "xxx",
-    "LDAP_PASSWORD": "xxx",
-    "LDAP_BASE_SEARCH": "xxx",
 
     # Instància de GN6 on voleu crear els tiquets
     "domini": "999",

--- a/soa/identitat.py
+++ b/soa/identitat.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import settings
 import re
 import requests

--- a/soa/identitat.py
+++ b/soa/identitat.py
@@ -2,6 +2,10 @@
 import settings
 import re
 import requests
+import ldap
+import logging
+
+logger = logging.getLogger()
 
 
 class GestioIdentitat:
@@ -13,12 +17,53 @@ class GestioIdentitat:
 
     def get_token(self):
         try:
-            resposta = requests.post(self.url+"/acls/processos",
+            resposta = requests.post(self.url + "/acls/processos",
                                      data={'idProces': settings.get("identitat_digital_apikey")})
             token = resposta.json()['tokenAcl']
             return token
-        except Exception:
+        except:
             return None
+
+    def ldap_search(self, l, mail, base_search):
+        # Scope has three options, SUBTREE searches all sub-folder/directories
+        scope = ldap.SCOPE_SUBTREE
+        # filter consists of a cn(common name) and keyword.
+        # putting asterisks around our keyword will match anything containing the string
+        # f = "cn=" + "*" + keyword + "*"
+        # Searching by mail
+        f = "(mail=" + mail + ')'
+        # determines which attributes to return. Returns all if set to "None"
+        retrieve_attributes = None
+        result_set = []
+        timeout = 0
+        # Get all the fields for the ldap entry (COMMENT IN DEVELOPMENT MODE)
+        result = l.search_s(base_search, scope, f, retrieve_attributes)
+        # print result[0][1].keys()
+        if len(result) != 0:
+            dn = result[0][0]
+            domain = dn.split(',' + base_search)[0].split('ou=')[-1]
+        try:
+            result_id = l.search(base_search, scope, f, retrieve_attributes)
+            while 1:
+                result_type, result_data = l.result(result_id, timeout)
+                if(result_data == []):
+                    break
+                else:
+                    if result_type == ldap.RES_SEARCH_ENTRY:
+                        result_set.append(result_data)
+            if len(result_set) == 0:
+                print "  No user found"
+                return
+            for i in range(len(result_set)):
+                for entry in result_set[i]:
+                    try:
+                        cn = entry[1]['cn'][0]
+                        logger.info("  cn: %s\n  dn: %s\n  domini: %s\n" % (cn, dn, domain))
+                        return cn
+                    except:
+                        pass
+        except ldap.LDAPError, e:
+            print e
 
     def canonicalitzar_mail(self, mail):
         if mail is None:
@@ -37,7 +82,6 @@ class GestioIdentitat:
 
         if not uid:
             uid = self.identitat_local.obtenir_uid_de_patrons(mail_canonic)
-
         return uid
 
     def obtenir_uid_remot(self, mail):
@@ -52,32 +96,53 @@ class GestioIdentitat:
                         self.url + "/externs/persones/" + cn + "/cn",
                         headers={'TOKEN': self.token}).json()
                     return persona['commonName']
-                except Exception:
+                except:
                     None
 
             # Si no hi ha correspondencia directa amb un usuari UPC
             # busquem a partir del mail qui pot ser
             cns = requests.get(self.url + "/externs/identitats?email=" + mail,
-                               headers={'TOKEN': self.token}).json()
-            if 'errorResponse' in cns:
-                return "-- None -- (Error en la resposta del Gestor de la Identitat)."
-            if len(cns) == 1:
-                # Quan tenim un resultat, es aquest
-                return cns['identitats'][0]['commonName']
+                               headers={'TOKEN': self.token})
+
+            # Si tenim resultats, són usuaris de GID (UPC/UPCNET)
+            if cns.content != '':
+                cns = cns.json()
+                if 'errorResponse' in cns:
+                    return "-- None -- (Error en la resposta del Gestor de la Identitat)."
+                if len(cns) == 1:
+                    # Quan tenim un resultat, es aquest
+                    return cns['identitats'][0]['commonName']
+                else:
+                    # Si tenim mes d'un, busquem el que te el mail que busquem
+                    # com a preferent o be retornem el primer
+                    for cn in cns:
+                        try:
+                            persona = requests.get(
+                                self.url + "/externs/persones/" + cn + "/cn",
+                                headers={'TOKEN': self.token}).json()
+                            email_preferent = persona['emailPreferent']
+                            if (self.canonicalitzar_mail(email_preferent) == mail):
+                                return persona['commonName']
+                        except:
+                            None
+                    return None
             else:
-                # Si tenim mes d'un, busquem el que te el mail que busquem
-                # com a preferent o be retornem el primer
-                for cn in cns:
-                    try:
-                        persona = requests.get(
-                            self.url + "/externs/persones/" + cn + "/cn",
-                            headers={'TOKEN': self.token}).json()
-                        email_preferent = persona['emailPreferent']
-                        if self.canonicalitzar_mail(email_preferent) == mail:
-                            return persona['commonName']
-                    except Exception:
-                        None
-                return None
+                # Tractem els usuaris de fora de la UPC amb el LDAP externs
+                # Initialize LDAP connection
+                LDAP_SERVER_URL = settings.get("LDAP_SERVER_URL")
+                LDAP_BIND_USER = settings.get("LDAP_BIND_USER")
+                LDAP_PASSWORD = settings.get("LDAP_PASSWORD")
+                LDAP_BASE_SEARCH = settings.get("LDAP_BASE_SEARCH")
+                ldap_server = ldap.initialize(LDAP_SERVER_URL)
+                try:
+                    ldap_server.protocol_version = ldap.VERSION3
+                    ldap_server.simple_bind_s(LDAP_BIND_USER, LDAP_PASSWORD)
+                    logger.info("Connected to : " + LDAP_SERVER_URL)
+                    logger.info("Search user  : " + mail)
+                    username = self.ldap_search(ldap_server, mail, LDAP_BASE_SEARCH)
+                    return username
+                except Exception, error:
+                    print error
         except Exception:
             return None
 

--- a/soa/identitat.py
+++ b/soa/identitat.py
@@ -29,7 +29,8 @@ class GestioIdentitat:
         # Scope has three options, SUBTREE searches all sub-folder/directories
         scope = ldap.SCOPE_SUBTREE
         # filter consists of a cn(common name) and keyword.
-        # putting asterisks around our keyword will match anything containing the string
+        # putting asterisks around our keyword will match anything containing
+        # the string
         # f = "cn=" + "*" + keyword + "*"
         # Searching by mail
         f = "(mail=" + mail + ')'
@@ -59,9 +60,10 @@ class GestioIdentitat:
                 for entry in result_set[i]:
                     try:
                         cn = entry[1]['cn'][0] + '@' + domain
-                        logger.info("  cn: %s\n  dn: %s\n  domini: %s\n" % (cn, dn, domain))
+                        logger.info("cn: %s\n  dn: %s\n  domini: %s\n"
+                                    % (cn, dn, domain))
                         return cn
-                    except:
+                    except Exception:
                         pass
         except ldap.LDAPError, e:
             print e
@@ -98,7 +100,7 @@ class GestioIdentitat:
                         headers={'TOKEN': self.token}).json()
                     logger.info("Correspon a un usuari UPC")
                     return persona['commonName']
-                except:
+                except Exception:
                     None
 
             # Si no hi ha correspondencia directa amb un usuari UPC
@@ -110,7 +112,8 @@ class GestioIdentitat:
             if cns.content != '':
                 cns = cns.json()
                 if 'errorResponse' in cns:
-                    return "-- None -- (Error en la resposta del Gestor de la Identitat)."
+                    return "-- None -- (Error en la resposta del Gestor de \
+                        la Identitat)."
                 if len(cns) == 1:
                     # Quan tenim un resultat, es aquest
                     return cns['identitats'][0]['commonName']
@@ -122,32 +125,33 @@ class GestioIdentitat:
                             persona = requests.get(
                                 self.url + "/externs/persones/" + cn + "/cn",
                                 headers={'TOKEN': self.token}).json()
-                            email_preferent = persona['emailPreferent']
-                            if (self.canonicalitzar_mail(email_preferent) == mail):
+                            preferent = persona['emailPreferent']
+                            if self.canonicalitzar_mail(preferent) == mail:
                                 logger.info("Correspon a un usuari GID")
                                 return persona['commonName']
-                        except:
+                        except Exception:
                             None
                     return None
             else:
                 # Tractem els usuaris de fora de la UPC amb el LDAP externs
                 # Initialize LDAP connection
                 if settings.get("LDAP_SERVER_URL") is not None and \
-                    settings.get("LDAP_BIND_USER") is not None and \
-                    settings.get("LDAP_PASSWORD") is not None and \
-                    settings.get("LDAP_BASE_SEARCH") is not None:
+                        settings.get("LDAP_BIND_USER") is not None and \
+                        settings.get("LDAP_PASSWORD") is not None and \
+                        settings.get("LDAP_BASE_SEARCH") is not None:
 
                     LDAP_SERVER_URL = settings.get("LDAP_SERVER_URL")
                     LDAP_BIND_USER = settings.get("LDAP_BIND_USER")
                     LDAP_PASSWORD = settings.get("LDAP_PASSWORD")
                     LDAP_BASE_SEARCH = settings.get("LDAP_BASE_SEARCH")
-                    ldap_server = ldap.initialize(LDAP_SERVER_URL)
+                    ldap_srv = ldap.initialize(LDAP_SERVER_URL)
                     try:
-                        ldap_server.protocol_version = ldap.VERSION3
-                        ldap_server.simple_bind_s(LDAP_BIND_USER, LDAP_PASSWORD)
+                        ldap_srv.protocol_version = ldap.VERSION3
+                        ldap_srv.simple_bind_s(LDAP_BIND_USER, LDAP_PASSWORD)
                         logger.info("Connected to : " + LDAP_SERVER_URL)
                         logger.info("Search user  : " + mail)
-                        username = self.ldap_search(ldap_server, mail, LDAP_BASE_SEARCH)
+                        username = self.ldap_search(ldap_srv, mail,
+                                                    LDAP_BASE_SEARCH)
                         logger.info("Correspon a un usuari extern")
                         return username
                     except Exception, error:

--- a/soa/identitat.py
+++ b/soa/identitat.py
@@ -31,6 +31,7 @@ class GestioIdentitat:
     def obtenir_uid(self, mail):
         mail_canonic = self.canonicalitzar_mail(mail)
         uid = self.identitat_local.obtenir_uid_de_llista(mail_canonic)
+
         if not uid:
             uid = self.obtenir_uid_remot(mail_canonic)
 
@@ -45,7 +46,6 @@ class GestioIdentitat:
             # digital un mail del tipus @upc.edu, aixi que primer comprovem
             # si la part esquerra del mail correspon a un usuari UPC real
             if "@upc.edu" in mail:
-                cn = mail.split("@")[0]
                 try:
                     cn = mail.split("@")[0]
                     persona = requests.get(
@@ -57,14 +57,13 @@ class GestioIdentitat:
 
             # Si no hi ha correspondencia directa amb un usuari UPC
             # busquem a partir del mail qui pot ser
-            cns = requests.get(self.url + "/externs/identitats/cn?email=" + mail,
+            cns = requests.get(self.url + "/externs/identitats?email=" + mail,
                                headers={'TOKEN': self.token}).json()
             if 'errorResponse' in cns:
                 return "-- None -- (Error en la resposta del Gestor de la Identitat)."
-
             if len(cns) == 1:
                 # Quan tenim un resultat, es aquest
-                return cns[0]
+                return cns['identitats'][0]['commonName']
             else:
                 # Si tenim mes d'un, busquem el que te el mail que busquem
                 # com a preferent o be retornem el primer

--- a/soa/identitat.py
+++ b/soa/identitat.py
@@ -57,7 +57,7 @@ class GestioIdentitat:
             for i in range(len(result_set)):
                 for entry in result_set[i]:
                     try:
-                        cn = entry[1]['cn'][0]
+                        cn = entry[1]['cn'][0] + '@' + domain
                         logger.info("  cn: %s\n  dn: %s\n  domini: %s\n" % (cn, dn, domain))
                         return cn
                     except:

--- a/soa/identitat.py
+++ b/soa/identitat.py
@@ -25,7 +25,7 @@ class GestioIdentitat:
         except Exception:
             return None
 
-    def ldap_search(self, l, mail, base_search):
+    def ldap_search(self, ldap, mail, base_search):
         # Scope has three options, SUBTREE searches all sub-folder/directories
         scope = ldap.SCOPE_SUBTREE
         # filter consists of a cn(common name) and keyword.
@@ -39,15 +39,15 @@ class GestioIdentitat:
         result_set = []
         timeout = 0
         # Get all the fields for the ldap entry (COMMENT IN DEVELOPMENT MODE)
-        result = l.search_s(base_search, scope, f, retrieve_attributes)
+        result = ldap.search_s(base_search, scope, f, retrieve_attributes)
         # print result[0][1].keys()
         if len(result) != 0:
             dn = result[0][0]
             domain = dn.split(',' + base_search)[0].split('ou=')[-1]
         try:
-            result_id = l.search(base_search, scope, f, retrieve_attributes)
+            result_id = ldap.search(base_search, scope, f, retrieve_attributes)
             while 1:
-                result_type, result_data = l.result(result_id, timeout)
+                result_type, result_data = ldap.result(result_id, timeout)
                 if(result_data == []):
                     break
                 else:

--- a/soa/service.py
+++ b/soa/service.py
@@ -11,7 +11,7 @@ class SOAService(object):
         self.client = Client(self.url)
         security = Security()
         security.tokens.append(
-                UsernameToken(self.username_soa, self.password_soa))
+            UsernameToken(self.username_soa, self.password_soa))
         self.client.set_options(wsse=security)
 
     @staticmethod

--- a/soa/service.py
+++ b/soa/service.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from suds.wsse import Security, UsernameToken
 from suds.client import Client
 import settings

--- a/soa/tiquets.py
+++ b/soa/tiquets.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from soa.service import SOAService
 import settings
 


### PR DESCRIPTION
Ser capaç de configurar una instància de mailtoticket per a que com a font de dades, a més a més de les ja existents, es pugui configurar un LDAP extern on l'eina pregunti si existeix i l'autoria del ticket creat estigui vinculada a aquest usuari d'aquest LDAP.

La intenció és que aquesta configuració sigui opcional i transparent. Quan parlo de transparent, vull dir que si ja hi ha instàncies de mailtoticket configurades, aquestes haurien de continuar funcionant correctament.