### PR TITLE
Migracio python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ instala.sh
 local
 .project
 .pydevproject
+.venv
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+  - "3.7"
 # command to install dependencies
 install: "pip install -r requirements.txt"
 # command to check before build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3.7
 
 WORKDIR /usr/src/app
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -yy libsasl2-dev libldap2-dev

--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ Aquest programa necessita els següents serveis SOA de la UPC:
 Us caldrà disposar d'un usuari i contrasenya per accedir al bus SOA.
 L'usuari i contrasenya del servei GN6 els podeu definir a la vostra instància.
 
-El llenguatge de programació triat és Python, vegeu el fitxer de [dependències](requirements.txt).
+El llenguatge de programació triat és Python 3, vegeu el fitxer de [dependències](requirements.txt).
 
 Per poder utilitzar aquest programa necessitareu configurar un _Mail Delivery Agent_ (MDA) al vostre servidor de correu o a la bústia IMAP corresponent.
 
 Instal·lació
 ------------
 
-La forma recomanada d'instal·lació és dins d'un _virtualenv_ de Python per poder gestionar les dependències sense permisos d'administrador:
+La forma recomanada d'instal·lació és dins d'un _virtualenv_ de Python 3 per poder gestionar les dependències sense permisos d'administrador:
 
 ```
 git clone https://github.com/UPC/mailtoticket.git
 cd mailtoticket
-virtualenv local
+virtualenv local -p python3
 echo "PATH=$PWD/local/bin:\$PATH" >> ~/.bashrc
 source ~/.bashrc
 pip install -r requirements.txt
@@ -39,7 +39,7 @@ Dockerització (pilot)
 
 ```
 docker build . -t mailtoticket
-cat missatge.txt | docker run -v /path/to/settings_default.py:/usr/src/app/settings_default.py:ro --rm -it mailtoticket
+cat missatge.txt | docker run -v /path/to/settings_default.py:/usr/src/app/settings_default.py:ro --rm -i mailtoticket
 ```
 
 

--- a/buscamail.py
+++ b/buscamail.py
@@ -3,11 +3,11 @@ from soa.identitat import GestioIdentitat
 import sys
 
 if len(sys.argv) < 2:
-    print "Has de posar un mail com a parametre"
+    print("Has de posar un mail com a parametre")
     sys.exit()
 
 if __name__ == '__main__':
     mail = sys.argv[1]
     identitat = GestioIdentitat()
     uid = identitat.obtenir_uid(mail)
-    print "El username associat a aquest mail es:" + uid
+    print("El username associat a aquest mail es:" + uid)

--- a/buscaticket.py
+++ b/buscaticket.py
@@ -3,11 +3,11 @@ from soa.tiquets import GestioTiquets
 import sys
 
 if len(sys.argv) < 2:
-    print "Has de posar un id de ticket com a parametre"
+    print("Has de posar un id de ticket com a parametre")
     sys.exit()
 
 id_ticket = sys.argv[1]
 tiquets = GestioTiquets()
-print tiquets.username_gn6
+print(tiquets.username_gn6)
 dades = tiquets.consulta_tiquet(id_ticket)
-print dades
+print(dades)

--- a/ldaphelper.py
+++ b/ldaphelper.py
@@ -53,7 +53,7 @@ class LDAP:
                     except Exception:
                         pass
         except ldap.LDAPError as error:
-            print (error)
+            print(error)
 
     def obtenir_uid_ldap(self):
         """Configura la connexio amb ldap i prepara la cerca."""
@@ -75,4 +75,4 @@ class LDAP:
             return username
         except Exception as error:
             logger.info("Error durant la cerca a LDAP")
-            print (error)
+            print(error)

--- a/mailticket.py
+++ b/mailticket.py
@@ -58,10 +58,10 @@ class MailTicket:
     def codifica(self, part):
         try:
             if part.get_content_charset() is not None:
-                s = unicode(part.get_payload(decode=True),
-                            part.get_content_charset(), "ignore")
+                s = str(part.get_payload(decode=True),
+                        part.get_content_charset(), "ignore")
             else:
-                s = unicode(part.get_payload(decode=True))
+                s = str(part.get_payload(decode=True))
         except Exception:
             # Tenim problemes per convertir, aixi que fem el que podem
             s = part.get_payload()
@@ -87,7 +87,7 @@ class MailTicket:
             return
 
         fragments = decode_header(subject)
-        resultat = u" ".join(map(lambda s: unicode(s[0], s[1] or "ascii"),
+        resultat = u" ".join(map(lambda s: str(s[0], s[1] or "ascii"),
                                  fragments))
 
         self.subject = resultat.replace('\n', ' ').replace('\r', '')

--- a/mailticket.py
+++ b/mailticket.py
@@ -4,7 +4,7 @@ import email
 import hashlib
 import base64
 import re
-from email.header import decode_header
+from email.header import decode_header, make_header
 from email.utils import parseaddr
 from email.utils import parsedate_tz, mktime_tz
 import datetime
@@ -87,8 +87,7 @@ class MailTicket:
             return
 
         fragments = decode_header(subject)
-        resultat = u" ".join(map(lambda s: str(s[0], s[1] or "ascii"),
-                                 fragments))
+        resultat = str(make_header(fragments))
 
         self.subject = resultat.replace('\n', ' ').replace('\r', '')
 

--- a/mailticket.py
+++ b/mailticket.py
@@ -24,7 +24,7 @@ class MailTicket:
             = settings.get("filtrar_attachments_per_hash")
         self.mails_no_ticket = settings.get("mails_no_ticket")
 
-        self.msg = email.message_from_file(fitxer)
+        self.msg = email.message_from_binary_file(fitxer)
         # Farem lazy initialization d'aquestes 2 properties per si hi ha
         # algun error
         self.body = None

--- a/mailticket.py
+++ b/mailticket.py
@@ -146,7 +146,7 @@ class MailTicket:
         return self.subject
 
     def get_subject_ascii(self):
-        return self.get_subject().encode('ascii', 'ignore')
+        return str(self.get_subject().encode('ascii', 'ignore'))
 
     def get_body(self):
         if self.body is None:

--- a/mailticket.py
+++ b/mailticket.py
@@ -56,23 +56,13 @@ class MailTicket:
                     break
 
     def codifica(self, part):
-        try:
-            if part.get_content_charset() is not None:
-                s = str(part.get_payload(decode=True),
-                        part.get_content_charset(), "ignore")
-            else:
-                s = str(part.get_payload(decode=True))
-        except Exception:
-            # Tenim problemes per convertir, aixi que fem el que podem
-            s = part.get_payload()
-
-        # Aixo es perque pot haver-hi caracters no imprimibles que s'han de
-        # filtrar. Nomes admetem els salts de linia, tabuladors i a partir
-        # del 32.
-        return "".join(
-            [x if ord(x) == 9 or ord(x) == 10 or ord(x) == 13 or ord(x) >= 32
-                else '' for x in s]
-        )
+        charset = part.get_content_charset()
+        if part.get("Content-Transfer-Encoding") \
+                in ['quoted-printable', 'base64'] \
+                and charset is not None:
+            return part.get_payload(decode=True).decode(charset)
+        else:
+            return part.get_payload()
 
     def nomes_ascii(self, s):
         return "".join(

--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
         )
     finally:
         mail.msg['X-Mailtoticket'] = estat
-        print mail
+        print(mail)
         logger.info("-----------------------------------------------------")
         if not tractat and settings.get("notificar_errors"):
             correu.enviar(buffer_logs.getvalue(), mail.msg)

--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
     try:
         logger.info("-----------------------------------------------------")
         logger.info("Llegeixo mail")
-        mail = MailTicket(sys.stdin)
+        mail = MailTicket(sys.stdin.buffer)
         logger.info("Mail de %s llegit amb ID %s"
                     % (mail.get_from(), mail.get_header('message-id')))
         if mail.cal_tractar():

--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -7,7 +7,7 @@ import correu
 import sys
 import getopt
 import logging
-from StringIO import StringIO
+from io import StringIO
 
 logger = logging.getLogger()
 

--- a/netejahtml.py
+++ b/netejahtml.py
@@ -101,7 +101,7 @@ def treure_tag_complet(html, tag):
     tags = soup.select(tag)
     for t in tags:
         t.decompose()
-    return unicode(soup)
+    return str(soup)
 
 
 @assegura_contingut
@@ -128,7 +128,7 @@ def treure_blockquote(html):
     if len(tags) == 1 and _es_prefix_reply_valid(tags[0]):
         tags[0].decompose()
 
-    return unicode(soup)
+    return str(soup)
 
 
 @assegura_contingut
@@ -188,7 +188,7 @@ def treure_signatura_html(html):
     if len(tags) >= 1:
         tags[len(tags) - 1].decompose()
 
-    return unicode(soup)
+    return str(soup)
 
 
 @assegura_contingut
@@ -198,7 +198,7 @@ def treure_imatges_trencades(html):
     for tag in tags:
         tag.decompose()
 
-    return unicode(soup)
+    return str(soup)
 
 
 @assegura_contingut

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 bleach
 mock>=1.3.0
-suds
+suds-jurko
 discover
 freezegun
 requests

--- a/soa/identitat.py
+++ b/soa/identitat.py
@@ -118,7 +118,7 @@ class GestioIdentitatLocal:
 
     def obtenir_uid_de_patrons(self, mail):
         try:
-            for k, v in self.patrons_mails_addicionals.iteritems():
+            for k, v in self.patrons_mails_addicionals.items():
                 patro = re.compile(k)
                 m = patro.match(mail)
                 if m:

--- a/test/test_mailticket.py
+++ b/test/test_mailticket.py
@@ -38,7 +38,7 @@ class TestMailTicket(unittest.TestCase):
     def test_get_body_buit(self):
         mail_buit = llegir_mail("mailbuit.txt")
         body = mail_buit.get_body()
-        self.assertEquals("", body)
+        self.assertEqual("", body)
 
     def test_get_auto_submitted(self):
         mail_buit = llegir_mail("mailbuit.txt")
@@ -53,12 +53,12 @@ class TestMailTicket(unittest.TestCase):
         apple_mail = MailTicket(StringIO(data))
 
         dt = apple_mail.get_date()
-        self.assertEquals("11/09/2015 11:45", dt.strftime("%d/%m/%Y %H:%M"))
+        self.assertEqual("11/09/2015 11:45", dt.strftime("%d/%m/%Y %H:%M"))
 
     def test_encoding_xungo(self):
         mail = llegir_mail("encoding-xungo.txt")
         body = mail.get_body()
-        self.assertNotEquals("", body)
+        self.assertNotEqual("", body)
 
 
 if __name__ == '__main__':

--- a/test/test_mailticket.py
+++ b/test/test_mailticket.py
@@ -4,7 +4,7 @@ import datetime
 from mailticket import MailTicket
 from test.testhelper import llegir_mail
 from freezegun import freeze_time
-from cStringIO import StringIO
+from io import StringIO
 
 
 class TestMailTicket(unittest.TestCase):

--- a/test/test_mailticket.py
+++ b/test/test_mailticket.py
@@ -2,7 +2,7 @@ import unittest
 import settings
 import datetime
 from mailticket import MailTicket
-from testhelper import llegir_mail
+from test.testhelper import llegir_mail
 from freezegun import freeze_time
 from cStringIO import StringIO
 

--- a/test/test_mailticket.py
+++ b/test/test_mailticket.py
@@ -59,6 +59,11 @@ class TestMailTicket(unittest.TestCase):
         body = mail.get_body()
         self.assertNotEqual("", body)
 
+    def test_quoted_printable(self):
+        mail = llegir_mail("comentaris.txt")
+        body = mail.get_body()
+        self.assertTrue("títol" in body)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_mailticket.py
+++ b/test/test_mailticket.py
@@ -2,9 +2,8 @@ import unittest
 import settings
 import datetime
 from mailticket import MailTicket
-from test.testhelper import llegir_mail
+from test.testhelper import llegir_mail, string_to_mail
 from freezegun import freeze_time
-from io import StringIO
 
 
 class TestMailTicket(unittest.TestCase):
@@ -13,7 +12,7 @@ class TestMailTicket(unittest.TestCase):
         settings.init()
         data = "From: foo@example.com\n" \
                "Date: Tue, 28 Sep 2016 10:24:09 +0200 (CEST)\n\n"
-        self.mail = MailTicket(StringIO(data))
+        self.mail = MailTicket(string_to_mail(data))
 
     def test_mails_no_ticket_0001(self):
         self.mail.mails_no_ticket = ["foo@example.com"]
@@ -50,7 +49,7 @@ class TestMailTicket(unittest.TestCase):
     def test_get_date_invalid_format(self):
         # Un missatge amb la data en format "Apple Mail"
         data = "Date: 9/23/2016 11:04:10 AM\n\n"
-        apple_mail = MailTicket(StringIO(data))
+        apple_mail = MailTicket(string_to_mail(data))
 
         dt = apple_mail.get_date()
         self.assertEqual("11/09/2015 11:45", dt.strftime("%d/%m/%Y %H:%M"))

--- a/test/test_neteja.py
+++ b/test/test_neteja.py
@@ -23,7 +23,7 @@ class TestNeteja(unittest.TestCase):
         msg = llegir_mail("comentaris.txt")
         html = msg.get_body()
         net = netejahtml.neteja_nou(html)
-        print net
+        print(net)
         self.assertFalse("supportList" in net)
 
 

--- a/test/test_neteja.py
+++ b/test/test_neteja.py
@@ -2,7 +2,7 @@
 
 import netejahtml
 import unittest
-from testhelper import llegir_mail
+from test.testhelper import llegir_mail
 
 
 class TestNeteja(unittest.TestCase):

--- a/test/test_reply.py
+++ b/test/test_reply.py
@@ -31,7 +31,7 @@ class TestReply(unittest.TestCase):
         f = FiltreReply(msg, self.tickets, self.identitat)
 
         self.assertTrue(f.es_aplicable())
-        self.assertEquals(f.solicitant, 'usuari.real')
+        self.assertEqual(f.solicitant, 'usuari.real')
 
     def test_reply_mail_extern_diferent_a_solicitant_detecta_usuari_extern(
             self):
@@ -41,7 +41,7 @@ class TestReply(unittest.TestCase):
         f = FiltreReply(msg, self.tickets, self.identitat)
 
         self.assertTrue(f.es_aplicable())
-        self.assertEquals(f.solicitant, 'usuari.extern')
+        self.assertEqual(f.solicitant, 'usuari.extern')
 
     def test_reply_ticket_id_dintre_de_message_id(
             self):
@@ -51,7 +51,7 @@ class TestReply(unittest.TestCase):
         f = FiltreReply(msg, self.tickets, self.identitat)
 
         self.assertTrue(f.es_aplicable())
-        self.assertEquals(f.ticket_id, "657421")
+        self.assertEqual(f.ticket_id, "657421")
 
 
 if __name__ == '__main__':

--- a/test/testhelper.py
+++ b/test/testhelper.py
@@ -2,12 +2,13 @@ from mailticket import MailTicket
 import os
 from io import BytesIO
 
+
 def llegir_mail(msgfile):
     fp = open(os.path.dirname(__file__) + "/mails/" + msgfile, "rb")
     mail_ticket = MailTicket(fp)
     fp.close()
     return mail_ticket
 
+
 def string_to_mail(data):
     return BytesIO(data.encode())
-

--- a/test/testhelper.py
+++ b/test/testhelper.py
@@ -1,9 +1,13 @@
 from mailticket import MailTicket
 import os
-
+from io import BytesIO
 
 def llegir_mail(msgfile):
-    fp = open(os.path.dirname(__file__) + "/mails/" + msgfile)
+    fp = open(os.path.dirname(__file__) + "/mails/" + msgfile, "rb")
     mail_ticket = MailTicket(fp)
     fp.close()
     return mail_ticket
+
+def string_to_mail(data):
+    return BytesIO(data.encode())
+


### PR DESCRIPTION
Canvis per suportar el pas a Python 3. A part dels canvis mes o menys mecanics, hi ha tota una part relacionada amb els encodings que ha costat una mica més.

Per fer aixo amb seguretat, s'han de passar també els testos interns, dels que també tenim una branca migracio-python3