### PR TITLE
Fem que funcionin els mails genèrics que no son son personals

### DIFF
--- a/soa/identitat.py
+++ b/soa/identitat.py
@@ -48,14 +48,15 @@ class GestioIdentitat:
             # Pot ser que un usuari d'un departament no tingui a identitat
             # digital un mail del tipus @upc.edu, aixi que primer comprovem
             # si la part esquerra del mail correspon a un usuari UPC real
+            # Fent la consulta a identitats en comptes de persones també
+            # tenim en compte els usuaris genèrics
             if "@upc.edu" in mail:
                 try:
-                    cn = mail.split("@")[0]
-                    persona = requests.get(
-                        self.url+"/externs/persones/"+cn+"/cn",
+                    requests.get(
+                        self.url+"/externs/identitats?cn="+cn,
                         headers={'TOKEN': self.token}).json()
                     logger.info("Correspon a un usuari UPC")
-                    return persona['commonName']
+                    return cn
                 except Exception:
                     None
 


### PR DESCRIPTION
Amb la implementació actual, quan un mail es @upc.edu, es mira si correspon a una persona, pero pot ser que sigui un mail generic com per exemple fib.cap.estudis. En aquest cas entrariem a la segona part on buscariem identitats que tinguin aquest mail, pero resulta que el mail oficial es cap.estudis@fib.upc.edu i per tant no trobariem identitat amb aquest mail.

Clarament aixo es un error, que solucionem simplement fent una consulta a identitats a partir del cn i si correspon a alguna, aquesta es la identitat a nom de la qual s'ha de crear el ticket