### PR TITLE
Detecció de signatura i mails citats a gmail al fer la neteja

### DIFF
--- a/netejahtml.py
+++ b/netejahtml.py
@@ -114,7 +114,7 @@ def treure_blockquote(html):
         tags[0].decompose()
 
     # gmail
-    tags = soup.select('body > div.gmail_extra')
+    tags = soup.select('body > div.gmail_quote')
     if len(tags) == 1:
         tags[0].decompose()
 

--- a/netejahtml.py
+++ b/netejahtml.py
@@ -187,6 +187,9 @@ def treure_signatura_html(html):
     tags = soup.select('.moz-signature')
     if len(tags) >= 1:
         tags[len(tags) - 1].decompose()
+    tags = soup.select('.gmail_signature')
+    if len(tags) >= 1:
+        tags[len(tags) - 1].decompose()
 
     return str(soup)
 


### PR DESCRIPTION
No s'estava detectant la signatura de gmail (bloc gmail_signatura) i els mails citats tenien una etiqueta incorrecta (gmail_extra en comptes de la correcta, gmail_quote).