### PR TITLE
Afegim el patro "Llegit:" per considerar el missatge automatic

### DIFF
--- a/mailticket.py
+++ b/mailticket.py
@@ -231,7 +231,8 @@ class MailTicket:
             or "Return Receipt" in self.get_body() \
             or "DELIVERY FAILURE" in self.get_subject() \
             or "Informe de lectura" in self.get_subject() \
-            or "Leer informe :" in self.get_subject()
+            or "Leer informe :" in self.get_subject() \
+            or "Llegit:" in self.get_subject()
 
     def cal_tractar(self):
         if self.comprova_mails_no_ticket():


### PR DESCRIPTION
Ens ha creat un ticket a partir d'un mail automàtic que començava per "Llegit:" i que mailtoticket no ha detectat. Hem afegit aquest patró a la llista