### PR TITLE
Afegim parametre per no imprimir el mail per stdout

### DIFF
--- a/mailtoticket.py
+++ b/mailtoticket.py
@@ -79,7 +79,9 @@ if __name__ == '__main__':
         )
     finally:
         mail.msg['X-Mailtoticket'] = estat
-        print(mail)
+        if not settings.get("no_escriure_sortida"):
+            print(mail)
+
         logger.info("-----------------------------------------------------")
         if not tractat and settings.get("notificar_errors"):
             correu.enviar(buffer_logs.getvalue(), mail.msg)


### PR DESCRIPTION
En un principi, podiem utilitzar mailtoticket com a filtre de maildrop en servidors propis de mail i era interessant tornar a escriure per la sortida el mail original amb una capçalera extra per dir que havia fet el mailtoticket amb el missatge.

Actualment només fa falta el codi d'error i aquest print només es soroll. Hem afegit un paràmetre per desactivar aquesta funcionalitat mantenint la compatibilitat, tot i que potser seria útil fer una enquesta per veure si encara cal arrossegar aixo o bé podem directament eliminar aquesta forma de funcionament i simplificar codi.