### PR TITLE
Afegim al ticket el mail al qual s'ha enviat

### DIFF
--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -60,8 +60,9 @@ class FiltreNou(Filtre):
         parametres_addicionals = self.obtenir_parametres_addicionals()
         logger.info("A veure si puc crear el ticket de %s" % self.solicitant)
         descripcio = (
-            "[Tiquet creat des del correu de %s del %s a les %s]<br><br>" % (
+            "[Tiquet creat des del correu de %s a %s del %s a les %s]<br><br>" % (
                 self.msg.get_from(),
+                self.msg.get_to(),
                 self.msg.get_date().strftime("%d/%m/%Y"),
                 self.msg.get_date().strftime("%H:%M")
             )

--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -60,13 +60,13 @@ class FiltreNou(Filtre):
         parametres_addicionals = self.obtenir_parametres_addicionals()
         logger.info("A veure si puc crear el ticket de %s" % self.solicitant)
         descripcio = (
-            "[Tiquet creat des del correu de %s a %s del %s a les %s]<br><br>" % (
+            "[Tiquet creat des del correu de %s a %s del %s a les %s]" % (
                 self.msg.get_from(),
                 self.msg.get_to(),
                 self.msg.get_date().strftime("%d/%m/%Y"),
                 self.msg.get_date().strftime("%H:%M")
             )
-        ) + body
+        ) + "<br><br>" + body
 
         parametres = {
             'assumpte': subject,


### PR DESCRIPTION
A la instancia de UTGCNTIC tenim molts alies de la bustia gestionada per mailtoticket i moltes regles que classifiquen el ticket en funció del mail al que s'ha enviat. Per veure errors en aquestes regles, es molt útil que al missatge aparegui no només qui ha enviat el mail i a quina hora, sino també a quina adreça l'ha enviat.