### PR TITLE
No enviem missatge de creació als externs

### DIFF
--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -12,6 +12,7 @@ class FiltreNou(Filtre):
 
     solicitant = None
     ticket_id = None
+    enviar_missatge_creacio = 'S'
 
     def es_aplicable(self):
         logger.info("Filtre de Nou")
@@ -22,7 +23,10 @@ class FiltreNou(Filtre):
         return self.solicitant is not None
 
     def obtenir_parametres_addicionals(self):
-        defaults = {"equipResolutor": settings.get("equip_resolutor_nous")}
+        defaults = {
+                    "equipResolutor": settings.get("equip_resolutor_nous"),
+                    "enviarMissatgeCreacio": self.enviar_missatge_creacio
+                    }
         if settings.get("valors_defecte") is None:
             return defaults
         for item in settings.get("valors_defecte"):

--- a/filtres/nou_extern.py
+++ b/filtres/nou_extern.py
@@ -10,4 +10,5 @@ class FiltreNouExtern(FiltreNou):
     def es_aplicable(self):
         logger.info("Filtre de Nou Extern, s'aplica sempre")
         self.solicitant = settings.get("usuari_extern")
+        self.enviar_missatge_creacio = 'N'
         return True


### PR DESCRIPTION
Quan es crea un ticket, s'envia un missatge de creació al solicitant amb un link al ticket per poder fer el seguiment i un missatge genèric.

En el cas d'un ticket creat amb un mail extern que no es mapeja a cap usuari UPC, aquest missatge es una mica absurd ja que no li donem cap informació útil i un link a on no pot accedir.

Per tant, es més lògic que aquest mail no s'envii quan es un usuari extern