### PR TITLE
Permetre que les regles funcionin amb capçaleres multivaluades

### DIFF
--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -32,11 +32,12 @@ class FiltreNou(Filtre):
         for item in settings.get("valors_defecte"):
             regex = re.compile(item['match'], re.IGNORECASE)
             for header_name in item['order']:
-                header_value = self.msg.get_header(header_name)
-                if header_value and regex.match(header_value):
-                    logger.info("Tinc parametres adicionals via %s"
+                header_values = self.msg.get_header(header_name).split(",")
+                for header_value in header_values:
+                    if header_value and regex.match(header_value):
+                        logger.info("Tinc parametres adicionals via %s"
                                 % header_name)
-                    defaults.update(item['defaults'])
+                        defaults.update(item['defaults'])
 
         logger.info("Parametres addicionals: %s" % str(defaults))
         return defaults

--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -36,7 +36,7 @@ class FiltreNou(Filtre):
                 for header_value in header_values:
                     if header_value and regex.match(header_value):
                         logger.info("Tinc parametres adicionals via %s"
-                                % header_name)
+                                    % header_name)
                         defaults.update(item['defaults'])
 
         logger.info("Parametres addicionals: %s" % str(defaults))

--- a/mailticket.py
+++ b/mailticket.py
@@ -97,7 +97,7 @@ class MailTicket:
         return emails
 
     def get_email_header(self, header):
-        emails=self.get_email_header_multiple(header)
+        emails = self.get_email_header_multiple(header)
         if len(emails) == 0:
             return None
         else:

--- a/mailticket.py
+++ b/mailticket.py
@@ -97,11 +97,11 @@ class MailTicket:
         return emails
 
     def get_email_header(self, header):
-        email = parseaddr(self.msg[header])[1]
-        if len(email) == 0:
+        emails=self.get_email_header_multiple(header)
+        if len(emails) == 0:
             return None
-
-        return email.lower()
+        else:
+            return ','.join(emails)
 
     def get_from(self):
         return self.get_email_header('From')

--- a/test/mails/cc.txt
+++ b/test/mails/cc.txt
@@ -1,0 +1,7 @@
+Subject: Mail amb multiples cc i to
+To: mail.qualsevol1@gmail.com, mail.concret1@mail.com
+CC: mail.qualsevol2@mail.com, mail.concret2@mail.com
+MIME-Version: 1.0
+Content-Type: text/plain
+
+Mail pel test de multiples capçaleres

--- a/test/test_regles.py
+++ b/test/test_regles.py
@@ -5,7 +5,7 @@ from soa.tiquets import GestioTiquets
 from soa.identitat import GestioIdentitat
 from filtres.nou import FiltreNou
 from mailticket import MailTicket
-from testhelper import llegir_mail
+from test.testhelper import llegir_mail
 
 
 class TestRegles(unittest.TestCase):

--- a/test/test_regles.py
+++ b/test/test_regles.py
@@ -1,0 +1,47 @@
+import unittest
+import mock
+import settings
+from soa.tiquets import GestioTiquets
+from soa.identitat import GestioIdentitat
+from filtres.nou import FiltreNou
+from mailticket import MailTicket
+from testhelper import llegir_mail
+
+
+class TestRegles(unittest.TestCase):
+
+    def setUp(self):
+        self.tickets = mock.create_autospec(GestioTiquets)
+        self.identitat = mock.create_autospec(GestioIdentitat)
+        settings.init()
+
+    def test_regla_amb_cc_comprova_primer_valor (self):
+        settings.set("valors_defecte", 
+            [
+                {"order":["Cc"],
+                    "match":"mail.qualsevol2@mail.com",
+                    "defaults":{"equipResolutor":"666"}
+                }
+            ]
+        )
+        msg = llegir_mail("cc.txt")
+        f = FiltreNou(msg, self.tickets, self.identitat)
+        defaults= f.obtenir_parametres_addicionals()
+        self.assertEqual(defaults["equipResolutor"], "666")
+
+    def test_regla_amb_cc_comprova_segon_valor (self):
+        settings.set("valors_defecte", 
+            [
+                {"order":["Cc"],
+                    "match":"mail.concret2@mail.com",
+                    "defaults":{"equipResolutor":"666"}
+                }
+            ]
+        )
+        msg = llegir_mail("cc.txt")
+        f = FiltreNou(msg, self.tickets, self.identitat)
+        defaults= f.obtenir_parametres_addicionals()
+        self.assertEqual(defaults["equipResolutor"], "666")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_regles.py
+++ b/test/test_regles.py
@@ -15,33 +15,34 @@ class TestRegles(unittest.TestCase):
         self.identitat = mock.create_autospec(GestioIdentitat)
         settings.init()
 
-    def test_regla_amb_cc_comprova_primer_valor (self):
-        settings.set("valors_defecte", 
-            [
-                {"order":["Cc"],
-                    "match":"mail.qualsevol2@mail.com",
-                    "defaults":{"equipResolutor":"666"}
-                }
-            ]
-        )
+    def test_regla_amb_cc_comprova_primer_valor(self):
+        settings.set("valors_defecte",
+                     [
+                        {
+                            "order": ["Cc"],
+                            "match": "mail.qualsevol2@mail.com",
+                            "defaults": {"equipResolutor": "666"}
+                        }
+                     ])
         msg = llegir_mail("cc.txt")
         f = FiltreNou(msg, self.tickets, self.identitat)
-        defaults= f.obtenir_parametres_addicionals()
+        defaults = f.obtenir_parametres_addicionals()
         self.assertEqual(defaults["equipResolutor"], "666")
 
-    def test_regla_amb_cc_comprova_segon_valor (self):
-        settings.set("valors_defecte", 
-            [
-                {"order":["Cc"],
-                    "match":"mail.concret2@mail.com",
-                    "defaults":{"equipResolutor":"666"}
-                }
-            ]
-        )
+    def test_regla_amb_cc_comprova_segon_valor(self):
+        settings.set("valors_defecte",
+                     [
+                        {
+                            "order": ["Cc"],
+                            "match": "mail.qualsevol2@mail.com",
+                            "defaults": {"equipResolutor": "666"}
+                        }
+                     ])
         msg = llegir_mail("cc.txt")
         f = FiltreNou(msg, self.tickets, self.identitat)
-        defaults= f.obtenir_parametres_addicionals()
+        defaults = f.obtenir_parametres_addicionals()
         self.assertEqual(defaults["equipResolutor"], "666")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Volem permetre regles per canviar els valors per defecte basades en capçaleres que poden tenir més d'un valor, com per exemple, les Cc.

Per fer aixo, varem un test per veure que efectivament només s'agafa el primer valor i després implementarem els canvis necessaris per obtenir tots els valors d'una capçalera i tenir-los en compte al motor de regles