### PR TITLE
Configuració de GitHub Actions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,28 @@
+name: Python application
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install build-essential libpython3-dev libsasl2-dev libldap2-dev
+        python -m compileall -f .
+        python -m pip install -r requirements.txt
+    - name: Run tests
+      run: |
+        python -m unittest discover

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MailToTicket
 Una pasarel·la de correu per al gestor de tiquets GN6.
 Per tenir una idea més precisa dels objectius d'aquest projecte, vegeu la [presentació del projecte](http://www.slideshare.net/angelaguilera/mailtoticket-presentaci-final-de-projecte) a la jornada de tancament Nexus24.
 
-[![Build Status](https://secure.travis-ci.org/UPC/mailtoticket.png?branch=master)](http://travis-ci.org/UPC/mailtoticket) [![Issue Count](https://codeclimate.com/github/UPC/mailtoticket/badges/issue_count.svg)](https://codeclimate.com/github/UPC/mailtoticket)
+[![Build Status (GH Actions)](https://github.com/UPC/mailtoticket/actions/workflows/python-app.yml/badge.svg)] [![Build Status (Travis CI)](https://secure.travis-ci.org/UPC/mailtoticket.png?branch=master)](http://travis-ci.org/UPC/mailtoticket) [![Issue Count](https://codeclimate.com/github/UPC/mailtoticket/badges/issue_count.svg)](https://codeclimate.com/github/UPC/mailtoticket)
 
 Requisits
 ---------

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MailToTicket
 Una pasarel·la de correu per al gestor de tiquets GN6.
 Per tenir una idea més precisa dels objectius d'aquest projecte, vegeu la [presentació del projecte](http://www.slideshare.net/angelaguilera/mailtoticket-presentaci-final-de-projecte) a la jornada de tancament Nexus24.
 
-[![Build Status (GH Actions)](https://github.com/UPC/mailtoticket/actions/workflows/python-app.yml/badge.svg)] [![Build Status (Travis CI)](https://secure.travis-ci.org/UPC/mailtoticket.png?branch=master)](http://travis-ci.org/UPC/mailtoticket) [![Issue Count](https://codeclimate.com/github/UPC/mailtoticket/badges/issue_count.svg)](https://codeclimate.com/github/UPC/mailtoticket)
+![Build Status (GH Actions)](https://github.com/UPC/mailtoticket/actions/workflows/python-app.yml/badge.svg) [![Build Status (Travis CI)](https://secure.travis-ci.org/UPC/mailtoticket.png?branch=master)](http://travis-ci.org/UPC/mailtoticket) [![Issue Count](https://codeclimate.com/github/UPC/mailtoticket/badges/issue_count.svg)](https://codeclimate.com/github/UPC/mailtoticket)
 
 Requisits
 ---------


### PR DESCRIPTION
Aquest PR configura el repo per tal d'executar els mateixos checks que tenim ara amb el Travis, però contra GitHub Actions.
La configuració del build és equivalent a la que tenim ara mateix per al Travis.