### PR TITLE
fix: compara literals amb '=='

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -10,13 +10,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ git:
 python:
   - "3.7"
   - "3.8"
+  - "3.9"
 # command to install dependencies
 install: "pip install -r requirements.txt"
 # command to check before build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ git:
   depth: false
 python:
   - "3.7"
+  - "3.8"
 # command to install dependencies
 install: "pip install -r requirements.txt"
 # command to check before build

--- a/mailticket.py
+++ b/mailticket.py
@@ -210,7 +210,7 @@ class MailTicket:
     def comprova_mails_contra_llista(self, llista):
         for item in llista:
             # Considera una regex si comença amb circumflex
-            regex = item if item[0] is '^' else '^' + re.escape(item) + '$'
+            regex = item if item[0] == '^' else '^' + re.escape(item) + '$'
             if re.compile(regex, re.UNICODE).match(self.get_from()):
                 return True
 


### PR DESCRIPTION
A partir de Python 3.8, la comparació amb literals
no s'hauria de fer amb 'is' sinó amb '=='.

Veure [més detalls](https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior).