### PR TITLE
Solució al problema   File '/home/lcadmin/mailtoticket/filtres/nou.py…

### DIFF
--- a/filtres/nou.py
+++ b/filtres/nou.py
@@ -32,12 +32,13 @@ class FiltreNou(Filtre):
         for item in settings.get("valors_defecte"):
             regex = re.compile(item['match'], re.IGNORECASE)
             for header_name in item['order']:
-                header_values = self.msg.get_header(header_name).split(",")
-                for header_value in header_values:
-                    if header_value and regex.match(header_value):
-                        logger.info("Tinc parametres adicionals via %s"
+                if self.msg.get_header(header_name):
+                    header_values = self.msg.get_header(header_name).split(",")
+                    for header_value in header_values:
+                        if header_value and regex.match(header_value):
+                            logger.info("Tinc parametres adicionals via %s"
                                     % header_name)
-                        defaults.update(item['defaults'])
+                            defaults.update(item['defaults'])
 
         logger.info("Parametres addicionals: %s" % str(defaults))
         return defaults


### PR DESCRIPTION
Donava l'error que s'ha solucionat amb aquest patch:

2021-07-21 10:55:40,520 [4007459] root         ERROR    Ha petat algun dels filtres i no marco el mail com a tractat
Traceback (most recent call last):
  File "/home/lcadmin/mailtoticket/mailtoticket.py", line 64, in <module>
    if filtres.aplicar_filtres(mail):
  File "/home/lcadmin/mailtoticket/filtres/__init__.py", line 52, in aplicar_filtres
    tractat = filtre.filtrar()
  File "/home/lcadmin/mailtoticket/filtres/nou.py", line 75, in filtrar
    parametres_addicionals = self.obtenir_parametres_addicionals()
  File "/home/lcadmin/mailtoticket/filtres/nou.py", line 35, in obtenir_parametres_addicionals
    header_values = self.msg.get_header(header_name).split(",")
AttributeError: 'NoneType' object has no attribute 'split'