### PR TITLE
Corregeix la configuració d'sphinx

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - epub
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: "3.7"
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
Fa temps que falla el build dels docs a mailtoticket.readthedocs.io,
segurament des de què vam afegir suport per LDAP ja que necessita que
hi hagi instal·lades les dependències de compilació.

Ara he indicat un fitxer de requisits independent per als docs, que no
conté res i no hauria de donar problemes.

https://docs.readthedocs.io/en/stable/config-file/v2.html